### PR TITLE
Fix compilation error

### DIFF
--- a/main/plugins/org.talend.designer.camel.resource/src/org/talend/designer/camel/resource/editors/RouteResoureChangeListener.java
+++ b/main/plugins/org.talend.designer.camel.resource/src/org/talend/designer/camel/resource/editors/RouteResoureChangeListener.java
@@ -81,7 +81,7 @@ public class RouteResoureChangeListener implements IResourceChangeListener {
 
                     if (resource.equals(editorFile)) {
 
-                        RepositoryWorkUnit<Object> repositoryWorkUnit = new RepositoryWorkUnit<Object>(SAVING_RESOURCE, this) {
+                        final RepositoryWorkUnit<Object> repositoryWorkUnit = new RepositoryWorkUnit<Object>(SAVING_RESOURCE, this) {
 
                             @Override
                             protected void run() throws LoginException, PersistenceException {


### PR DESCRIPTION
Mark 'repositoryWorkUnit' final in order to get rid of error 'Cannot refer to the non-final local variable repositoryWorkUnit defined in an enclosing scope'.