### PR TITLE
TESB-18278 - give nested routelets a unique name

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
@@ -88,8 +88,8 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
         manager.setBundleVersion(version);
     }
 
-    public JavaCamelJobScriptsExportWSAction(Map<ExportChoice, Object> exportChoiceMap, IRepositoryNode routeNode,
-            String version, String destinationKar, boolean addStatisticsCode) {
+    public JavaCamelJobScriptsExportWSAction(Map<ExportChoice, Object> exportChoiceMap, IRepositoryNode routeNode, String version,
+            String destinationKar, boolean addStatisticsCode) {
         this.routeNode = routeNode;
         this.version = version;
         this.bundleVersion = version;
@@ -107,7 +107,7 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
     }
 
     private Map<ExportChoice, Object> getExportChoice() {
-        Map<ExportChoice, Object> exportChoiceMap = new EnumMap<ExportChoice, Object>(ExportChoice.class);
+        Map<ExportChoice, Object> exportChoiceMap = new EnumMap<>(ExportChoice.class);
         exportChoiceMap.put(ExportChoice.needJobItem, false);
         exportChoiceMap.put(ExportChoice.needSourceCode, false);
         exportChoiceMap.put(ExportChoice.needMetaInfo, true);
@@ -125,9 +125,8 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
     }
 
     protected String getJobGroupId(String jobId, String jobName) {
-    	String defaultProjectName = JavaResourcesHelper.getProjectFolderName(
-    			routeNode.getObject().getProperty().getItem());
-    	return CamelFeatureUtil.getMavenGroupId(jobId, jobName, defaultProjectName);
+        String defaultProjectName = JavaResourcesHelper.getProjectFolderName(routeNode.getObject().getProperty().getItem());
+        return CamelFeatureUtil.getMavenGroupId(jobId, jobName, defaultProjectName);
     }
 
     protected String getArtifactId() {
@@ -161,8 +160,8 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                 featuresModel.setContexts(JobContextUtils.getContextsMap(routeProcess));
 
                 exportAllReferenceJobs(routeProcess);
-                final Collection<String> routelets = new HashSet<String>();
-                exportAllReferenceRoutelets(routeProcess, routelets);
+                final Collection<String> routelets = new HashSet<>();
+                exportAllReferenceRoutelets(routeName, routeProcess, routelets);
 
                 exportRouteBundle(routeNode, routeFile, version, bundleVersion, routelets, null);
             }
@@ -175,7 +174,8 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
         }
     }
 
-    protected void processResults(FeaturesModel featuresModel, IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+    protected void processResults(FeaturesModel featuresModel, IProgressMonitor monitor)
+            throws InvocationTargetException, InterruptedException {
         // create kar file
         try {
             new ZipModel(featuresModel, new File(destinationKar));
@@ -202,7 +202,7 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                     jobId = ept.getValue();
                 } else if ("SELECTED_JOB_NAME:PROCESS_TYPE_VERSION".equals(eptName)) { //$NON-NLS-1$
                     jobVersion = ept.getValue();
-                } else  if ("SELECTED_JOB_NAME:PROCESS_TYPE_CONTEXT".equals(eptName)) { //$NON-NLS-1$
+                } else if ("SELECTED_JOB_NAME:PROCESS_TYPE_CONTEXT".equals(eptName)) { //$NON-NLS-1$
                     jobContext = ept.getValue();
                 }
             }
@@ -228,31 +228,32 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                 throw new InvocationTargetException(e);
             }
             String jobArtifactVersion = jobVersion;
-            if(getArtifactVersion().endsWith("-SNAPSHOT")) {
-            	jobArtifactVersion += "-SNAPSHOT";
+            if (getArtifactVersion().endsWith("-SNAPSHOT")) {
+                jobArtifactVersion += "-SNAPSHOT";
             }
-            // String routeName = routeNode.getObject().getProperty().getDisplayName();
-            BundleModel jobModel = new BundleModel(getJobGroupId(jobId, jobName), jobName + "-bundle", jobArtifactVersion, jobFile);
+            BundleModel jobModel = new BundleModel(getJobGroupId(jobId, jobName), jobName + "-bundle", jobArtifactVersion,
+                    jobFile);
             if (featuresModel.addBundle(jobModel)) {
-                exportRouteUsedJobBundle(referencedJobNode, jobFile, jobVersion, jobName, jobVersion, routeNode
-                    .getObject().getProperty().getDisplayName(), version, jobContext);
+                exportRouteUsedJobBundle(referencedJobNode, jobFile, jobVersion, jobName, jobVersion,
+                        routeNode.getObject().getProperty().getDisplayName(), version, jobContext);
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-	protected void exportAllReferenceRoutelets(ProcessItem routeProcess, Collection<String> routelets) throws InvocationTargetException, InterruptedException {
+    protected void exportAllReferenceRoutelets(String routeName, ProcessItem routeProcess, Collection<String> routelets)
+            throws InvocationTargetException, InterruptedException {
         for (NodeType node : (Collection<NodeType>) routeProcess.getProcess().getNode()) {
             if (!EmfModelUtils.isComponentActive(node)) {
                 continue;
             }
-            final ElementParameterType routeletId =
-                EmfModelUtils.findElementParameterByName(EParameterName.PROCESS_TYPE.getName() + ':' + EParameterName.PROCESS_TYPE_PROCESS.getName(), node);
+            final ElementParameterType routeletId = EmfModelUtils.findElementParameterByName(
+                    EParameterName.PROCESS_TYPE.getName() + ':' + EParameterName.PROCESS_TYPE_PROCESS.getName(), node);
             if (null != routeletId) {
                 final IRepositoryNode referencedRouteletNode;
                 try {
-                    referencedRouteletNode =
-                        getJobRepositoryNode(routeletId.getValue(), CamelRepositoryNodeType.repositoryRouteletType);//getRouteletRepositoryNode(routeletId);
+                    referencedRouteletNode = getJobRepositoryNode(routeletId.getValue(),
+                            CamelRepositoryNodeType.repositoryRouteletType);// getRouteletRepositoryNode(routeletId);
                 } catch (PersistenceException e) {
                     throw new InvocationTargetException(e);
                 }
@@ -263,8 +264,10 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                     continue;
                 }
 
-                String routeletVersion =
-                    EmfModelUtils.findElementParameterByName(EParameterName.PROCESS_TYPE.getName() + ':' + EParameterName.PROCESS_TYPE_VERSION.getName(), node).getValue();
+                String routeletVersion = EmfModelUtils
+                        .findElementParameterByName(
+                                EParameterName.PROCESS_TYPE.getName() + ':' + EParameterName.PROCESS_TYPE_VERSION.getName(), node)
+                        .getValue();
                 if (RelationshipItemBuilder.LATEST_VERSION.equals(routeletVersion)) {
                     routeletVersion = referencedRouteletNode.getObject().getVersion();
                 }
@@ -275,20 +278,23 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                 } catch (IOException e) {
                     throw new InvocationTargetException(e);
                 }
-                BundleModel jobModel = new BundleModel(getGroupId(), referencedRouteletNode.getObject().getLabel(), getArtifactVersion(), routeletFile);
+                String routeletName = routeName + "_" + referencedRouteletNode.getObject().getLabel();
+                BundleModel jobModel = new BundleModel(getGroupId(), routeletName, getArtifactVersion(), routeletFile);
                 if (featuresModel.addBundle(jobModel)) {
                     exportRouteBundle(referencedRouteletNode, routeletFile, routeletVersion, routeletVersion, null,
-                        EmfModelUtils.findElementParameterByName(EParameterName.PROCESS_TYPE.getName() + ':' + EParameterName.PROCESS_TYPE_CONTEXT.getName(), node).getValue());
+                            EmfModelUtils.findElementParameterByName(
+                                    EParameterName.PROCESS_TYPE.getName() + ':' + EParameterName.PROCESS_TYPE_CONTEXT.getName(),
+                                    node).getValue());
                     CamelFeatureUtil.addFeatureAndBundles(routeletProcess, featuresModel);
 
-                    exportAllReferenceRoutelets(routeletProcess, routelets);
+                    exportAllReferenceRoutelets(routeName, routeletProcess, routelets);
                 }
             }
         }
     }
 
     private static IRepositoryNode getJobRepositoryNode(String jobId, ERepositoryObjectType type) throws PersistenceException {
-        List<IRepositoryViewObject> list = new ArrayList<IRepositoryViewObject>();
+        List<IRepositoryViewObject> list = new ArrayList<>();
         List<Project> projects = ProjectManager.getInstance().getAllReferencedProjects();
         for (Project p : projects) {
             list.addAll(ProxyRepositoryFactory.getInstance().getAll(p, type));
@@ -304,20 +310,10 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
         return null;
     }
 
-//    private static IRepositoryNode getRouteletRepositoryNode(String routeletName) throws PersistenceException {
-//        for (IRepositoryViewObject routelet : ProxyRepositoryFactory.getInstance().getAll(
-//            CamelRepositoryNodeType.repositoryRouteletType)) {
-//            if (routelet.getLabel().equals(routeletName)) {
-//                return new RepositoryNode(routelet, null, ENodeType.REPOSITORY_ELEMENT);
-//            }
-//        }
-//        return null;
-//    }
-
     private void exportRouteBundle(IRepositoryNode node, File filePath, String version, String bundleVersion,
-        Collection<String> routelets, String context) throws InvocationTargetException, InterruptedException {
-        final JobJavaScriptOSGIForESBManager talendJobManager =
-            new RouteJavaScriptOSGIForESBManager(getExportChoice(), context, routelets);
+            Collection<String> routelets, String context) throws InvocationTargetException, InterruptedException {
+        final JobJavaScriptOSGIForESBManager talendJobManager = new RouteJavaScriptOSGIForESBManager(getExportChoice(), context,
+                routelets);
         talendJobManager.setBundleVersion(bundleVersion);
         talendJobManager.setMultiNodes(false);
         talendJobManager.setDestinationPath(filePath.getAbsolutePath());
@@ -326,23 +322,23 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
         action.run(monitor);
     }
 
-    protected void exportRouteUsedJobBundle(IRepositoryNode node, File filePath, String jobVersion,
-    		String bundleName, String bundleVersion,
-    		String routeName, String routeVersion, String context) throws InvocationTargetException, InterruptedException {
-    	RouteUsedJobManager talendJobManager = new RouteUsedJobManager(getExportChoice(), context);
+    protected void exportRouteUsedJobBundle(IRepositoryNode node, File filePath, String jobVersion, String bundleName,
+            String bundleVersion, String routeName, String routeVersion, String context)
+            throws InvocationTargetException, InterruptedException {
+        RouteUsedJobManager talendJobManager = new RouteUsedJobManager(getExportChoice(), context);
         talendJobManager.setJobVersion(jobVersion);
         talendJobManager.setBundleName(bundleName);
         talendJobManager.setBundleVersion(bundleVersion);
         talendJobManager.setDestinationPath(filePath.getAbsolutePath());
-    	talendJobManager.setRouteName(routeName);
-    	talendJobManager.setRouteVersion(routeVersion);
-    	talendJobManager.setGroupId(getGroupId());
-    	talendJobManager.setArtifactId(getArtifactId());
-    	talendJobManager.setArtifactVersion(getArtifactVersion());
+        talendJobManager.setRouteName(routeName);
+        talendJobManager.setRouteVersion(routeVersion);
+        talendJobManager.setGroupId(getGroupId());
+        talendJobManager.setArtifactId(getArtifactId());
+        talendJobManager.setArtifactVersion(getArtifactVersion());
         JobExportAction action = new JobExportAction(Collections.singletonList(node), jobVersion, bundleVersion, talendJobManager,
                 getTempDir(), "Job");
         action.run(monitor);
-	}
+    }
 
     protected static String getTempDir() {
         String path = System.getProperty("java.io.tmpdir") + File.separatorChar + "route" + File.separatorChar; //$NON-NLS-1$

--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWithMavenAction.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWithMavenAction.java
@@ -47,14 +47,15 @@ public class JavaCamelJobScriptsExportWithMavenAction extends JavaCamelJobScript
             destinationKar = getTempDir() + File.separatorChar + getNodeBundleName(routeNode, version)
                     + FileConstants.KAR_FILE_SUFFIX;
         }
-        KarafJavaScriptForESBWithMavenManager sm = new KarafJavaScriptForESBWithMavenManager(exportChoiceMap, destinationKar, null, null,
-                IProcessor.NO_STATISTICS, IProcessor.NO_TRACES, "Route");
+        KarafJavaScriptForESBWithMavenManager sm = new KarafJavaScriptForESBWithMavenManager(exportChoiceMap, destinationKar,
+                null, null, IProcessor.NO_STATISTICS, IProcessor.NO_TRACES, "Route");
         sm.setReferenceRoutelets(getReferenceRoutlets());
         scriptsManager = sm;
     }
 
     @Override
-    protected void processResults(FeaturesModel featuresModel, IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+    protected void processResults(FeaturesModel featuresModel, IProgressMonitor monitor)
+            throws InvocationTargetException, InterruptedException {
         super.processResults(featuresModel, monitor);
 
         exportMavenResources(monitor);
@@ -63,8 +64,8 @@ public class JavaCamelJobScriptsExportWithMavenAction extends JavaCamelJobScript
     private void exportMavenResources(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
         scriptsManager.setMultiNodes(false);
         scriptsManager.setDestinationPath(destinationPath);
-        JobExportAction action = new JobExportAction(Collections.singletonList(routeNode), version, bundleVersion,
-                scriptsManager, getTempDir(), "Route"); //$NON-NLS-1$
+        JobExportAction action = new JobExportAction(Collections.singletonList(routeNode), version, bundleVersion, scriptsManager,
+                getTempDir(), "Route"); //$NON-NLS-1$
         action.run(monitor);
     }
 
@@ -74,11 +75,12 @@ public class JavaCamelJobScriptsExportWithMavenAction extends JavaCamelJobScript
 
     private Collection<String> getReferenceRoutlets() {
         ProcessItem routeProcess = (ProcessItem) routeNode.getObject().getProperty().getItem();
-        Collection<String> routelets = new HashSet<String>();
+        String routeName = routeNode.getObject().getProperty().getDisplayName();
+        Collection<String> routelets = new HashSet<>();
         try {
-            exportAllReferenceRoutelets(routeProcess, routelets);
+            exportAllReferenceRoutelets(routeName, routeProcess, routelets);
         } catch (InvocationTargetException e) {
-            return  new HashSet<String>();
+            return new HashSet<>();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }


### PR DESCRIPTION
This adds the name of to-be-exported route as a prefix to all nested routelets. Apart from that, the Talend code style guides were applied to the changed classes.