### PR TITLE
fix the 2nd issue of TESB-17533

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <spring4.version>4.2.7.RELEASE</spring4.version>
     <spring.boot.version>1.2.8.RELEASE</spring.boot.version>
     <scala.version>2.11.7</scala.version>
-    <jettison.version>1.3.7</jettison.version>
+    <jettison.version>1.3.8</jettison.version>
     <!--slf4j.version>1.7.9</slf4j.version-->
     <tesb.version>${maven.compatible.version}</tesb.version>
 


### PR DESCRIPTION
jettison 1.3.7 lib has a problem which convert int to string, we need to upgrade it to 1.3.8 (which is also the right jettison version used by cxf 3.1.11 in Runtime)