### PR TITLE
Enable WSDL schema validation for Standard Edition

### DIFF
--- a/main/plugins/org.talend.repository.services/src/org/talend/repository/services/ui/ServiceMetadataDialog.java
+++ b/main/plugins/org.talend.repository.services/src/org/talend/repository/services/ui/ServiceMetadataDialog.java
@@ -125,18 +125,17 @@ public class ServiceMetadataDialog extends HelpAvailableDialog {
         
         Group samSlGroup = new Group(container, SWT.NONE);        
         Button schemaValidationCheck = null ;
-        if(isStudioEEVersion()){
-        	schemaValidationCheck = new Button(samSlGroup, SWT.CHECK);
-            schemaValidationCheck.setText("Use WSDL Schema Validation");
-            schemaValidationCheck.setSelection(wsdlSchemaValidation);
-            schemaValidationCheck.setEnabled(!useServiceRegistry);        
-            schemaValidationCheck.addSelectionListener(new SelectionAdapter() {
-            	public void widgetSelected(SelectionEvent e) {
-            		wsdlSchemaValidation = ((Button)e.widget).getSelection();
+
+        schemaValidationCheck = new Button(samSlGroup, SWT.CHECK);
+        schemaValidationCheck.setText("Use WSDL Schema Validation");
+        schemaValidationCheck.setSelection(wsdlSchemaValidation);
+        schemaValidationCheck.setEnabled(!useServiceRegistry);        
+        schemaValidationCheck.addSelectionListener(new SelectionAdapter() {
+        	public void widgetSelected(SelectionEvent e) {
+        		wsdlSchemaValidation = ((Button)e.widget).getSelection();
             	}
             });
-        }else{
-        	wsdlSchemaValidation = false;
+
         }
         final Button tmpSchemaValidationCheck = schemaValidationCheck;
         


### PR DESCRIPTION
For some reason "Use WSDL Schema Validation" checkbox was not present in TESB-SE. This is purely CXF feature and it does not require any components from TESB-EE such as Service Registry. One can just add "<entry key="schema-validation-enabled" value="true" />" to the service blueprint to achieve exactly same effect.
Lack of this switch in the UI is just pain in the a**, and it unnecessarily makes people lives harder.

https://jira.talendforge.org/browse/TESB-19953