### PR TITLE
TESB-21070 TESB-21258 tRESTRequest bug fix, endpoint improvement

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.ws.crest/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.designer.esb.components.ws.crest/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: WS provider
+Bundle-Name: %pluginName
 Bundle-SymbolicName: org.talend.designer.esb.components.ws.crest;singleton:=true
 Bundle-Version: 7.0.1.qualifier
-Bundle-Vendor: .Talend SA.
+Bundle-Vendor: %providerName
 Bundle-Activator: org.talend.designer.esb.components.ws.crest.CRESTPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,
@@ -21,4 +21,4 @@ Require-Bundle: org.eclipse.ui,
  org.talend.libraries.apache,
  org.apache.xerces,
  org.talend.designer.esb.components.ws.tools.extensions;bundle-version="7.0.1"
-Eclipse-BundleShape: dir
+

--- a/main/plugins/org.talend.designer.esb.components.ws.crest/plugin.properties
+++ b/main/plugins/org.talend.designer.esb.components.ws.crest/plugin.properties
@@ -1,0 +1,20 @@
+
+# <copyright>
+# </copyright>
+#
+# $Id$
+
+# ====================================================================
+# To code developer:
+#   Do NOT change the properties between this line and the
+#   "%%% END OF TRANSLATED PROPERTIES %%%" line.
+#   Make a new property name, append to the end of the file and change
+#   the code to use the new property.
+# ====================================================================
+
+# ====================================================================
+# %%% END OF TRANSLATED PROPERTIES %%%
+# ====================================================================
+
+pluginName = cREST component initialization tool
+providerName = .Talend SA.

--- a/main/plugins/org.talend.designer.esb.components.ws.crest/src/org/talend/designer/esb/components/ws/crest/CRESTConstants.java
+++ b/main/plugins/org.talend.designer.esb.components.ws.crest/src/org/talend/designer/esb/components/ws/crest/CRESTConstants.java
@@ -2,6 +2,8 @@ package org.talend.designer.esb.components.ws.crest;
 
 public interface CRESTConstants {
 
+    String PREF_KEEP_ENDPOINT = "PREF_KEEP_ENDPOINT";
+
     String URL = "URL"; // scheme + host + port
 
     String PATH = "PATH"; // endpoint

--- a/main/plugins/org.talend.designer.esb.components.ws.crest/src/org/talend/designer/esb/components/ws/crest/CRESTNode.java
+++ b/main/plugins/org.talend.designer.esb.components.ws.crest/src/org/talend/designer/esb/components/ws/crest/CRESTNode.java
@@ -115,7 +115,7 @@ public class CRESTNode extends AbstractExternalNode {
                     case SUCCESS:
                         if (crestNodeAdapter.isNodeToDefaultValues()) {
                             if (MessageDialogWithLink.openConfirm(shell, "Confirm component initialization",
-                                    "Initialize component?")) {
+                                    "Initialize component?", "", "", false)) {
                                 crestNodeAdapter.setNodeSetting(oasManager);
                                 return SWT.OK;
                             } else {
@@ -123,7 +123,8 @@ public class CRESTNode extends AbstractExternalNode {
                             }
                         } else {
                             if (MessageDialogWithLink.openConfirm(shell, "Confirm component initialization",
-                                    "Initialize component?\n\nYour existing endpoint, API mappings and documentation will be overridden.")) {
+                                    "Initialize component?\n\nYour existing endpoint, API mappings and documentation will be overridden.",
+                                    "", "", crestNodeAdapter.isEndpointNotNull())) {
                                 crestNodeAdapter.setNodeSetting(oasManager);
                                 return SWT.OK;
                             } else {
@@ -132,8 +133,9 @@ public class CRESTNode extends AbstractExternalNode {
                         }
                     case SUCCESS_WITH_WARNINGS:
                         boolean confirm = MessageDialogWithLink.openConfirm(shell, "Confirm component initialization",
-                                "Initialize component?\nYour existing endpoint, API mappings and documentation will be overridden.\n\nIf some parts seem missing in your initialized component, please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
-                                "https://studio.restlet.com");
+                                "Initialize component?\nYour existing endpoint, API mappings and documentation will be overridden.",
+                                "If some parts seem missing in your initialized component, please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
+                                "https://studio.restlet.com", crestNodeAdapter.isEndpointNotNull());
 
                         if (confirm) {
                             crestNodeAdapter.setNodeSetting(oasManager);
@@ -143,8 +145,9 @@ public class CRESTNode extends AbstractExternalNode {
                         }
                     case ERROR:
                         MessageDialogWithLink.openError(shell, "OAS/Swagger 2.0 import error",
-                                "We were unable to initialize your component from your OAS/Swagger 2.0 definition.\n\nPlease check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
-                                "https://studio.restlet.com");
+                                "We were unable to initialize your component from your OAS/Swagger 2.0 definition.",
+                                "Please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
+                                "https://studio.restlet.com", false);
                         return SWT.CANCEL;
                     default:
                         return SWT.CANCEL;
@@ -157,8 +160,9 @@ public class CRESTNode extends AbstractExternalNode {
                 }
             } catch (TranslationException e) {
                 MessageDialogWithLink.openError(shell, "OAS/Swagger 2.0 import error",
-                        "We were unable to initialize your component from your OAS/Swagger 2.0 definition.\n\nPlease check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
-                        "https://studio.restlet.com");
+                        "We were unable to initialize your component from your OAS/Swagger 2.0 definition.",
+                        "Please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.", "https://studio.restlet.com",
+                        false);
                 return SWT.CANCEL;
             }
         } else {

--- a/main/plugins/org.talend.designer.esb.components.ws.crest/src/org/talend/designer/esb/components/ws/crest/CRESTNodeAdapter.java
+++ b/main/plugins/org.talend.designer.esb.components.ws.crest/src/org/talend/designer/esb/components/ws/crest/CRESTNodeAdapter.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.talend.core.model.process.IElementParameter;
 import org.talend.core.model.utils.TalendTextUtils;
 import org.talend.designer.esb.components.ws.tools.extensions.external.IOASDecoder;
@@ -31,15 +32,21 @@ public class CRESTNodeAdapter implements CRESTConstants {
 
     protected CRESTNode node;
 
+    private IPreferenceStore prefs;
+
     public CRESTNodeAdapter(CRESTNode node) {
         this.node = node;
+        this.prefs = CRESTPlugin.getDefault().getPreferenceStore();
     }
 
     @SuppressWarnings("unchecked")
     public IStatus setNodeSetting(IOASDecoder oasManager) {
 
         // endpoint
-        node.setParamValue(URL, TalendTextUtils.addQuotes(oasManager.getEndpoint()));
+        boolean keepEndpointValue = prefs.getBoolean(CRESTConstants.PREF_KEEP_ENDPOINT);
+        if (StringUtils.isBlank(TalendTextUtils.removeQuotes(node.getParamStringValue(URL))) || !keepEndpointValue) {
+            node.setParamValue(URL, TalendTextUtils.addQuotes(oasManager.getEndpoint()));
+        }
 
         node.setParamValue(SERVICE_TYPE, "MANUAL");
 
@@ -68,6 +75,10 @@ public class CRESTNodeAdapter implements CRESTConstants {
         node.setParamValue(COMMENT, oasManager.getDocumentationComment());
 
         return Status.OK_STATUS;
+    }
+
+    public boolean isEndpointNotNull() {
+        return StringUtils.isNotBlank(TalendTextUtils.removeQuotes(node.getParamStringValue(URL)));
     }
 
     @SuppressWarnings("unchecked")

--- a/main/plugins/org.talend.designer.esb.components.ws.trestrequest/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.designer.esb.components.ws.trestrequest/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: WS provider
+Bundle-Name: %pluginName
 Bundle-SymbolicName: org.talend.designer.esb.components.ws.trestrequest;singleton:=true
 Bundle-Version: 7.0.1.qualifier
-Bundle-Vendor: .Talend SA.
+Bundle-Vendor: %providerName
 Bundle-Activator: org.talend.designer.esb.components.ws.trestrequest.TRESTRequestPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,
@@ -20,5 +20,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.ecore.xmi,
  org.talend.libraries.apache,
  org.apache.xerces,
- org.talend.designer.esb.components.ws.tools.extensions;bundle-version="7.0.1"
+ org.talend.designer.esb.components.ws.tools.extensions
 Eclipse-BundleShape: dir

--- a/main/plugins/org.talend.designer.esb.components.ws.trestrequest/plugin.properties
+++ b/main/plugins/org.talend.designer.esb.components.ws.trestrequest/plugin.properties
@@ -1,0 +1,20 @@
+
+# <copyright>
+# </copyright>
+#
+# $Id$
+
+# ====================================================================
+# To code developer:
+#   Do NOT change the properties between this line and the
+#   "%%% END OF TRANSLATED PROPERTIES %%%" line.
+#   Make a new property name, append to the end of the file and change
+#   the code to use the new property.
+# ====================================================================
+
+# ====================================================================
+# %%% END OF TRANSLATED PROPERTIES %%%
+# ====================================================================
+
+pluginName = tRESTRequest component initialization tool
+providerName = .Talend SA.

--- a/main/plugins/org.talend.designer.esb.components.ws.trestrequest/src/org/talend/designer/esb/components/ws/trestrequest/MessageDialogWithLink.java
+++ b/main/plugins/org.talend.designer.esb.components.ws.trestrequest/src/org/talend/designer/esb/components/ws/trestrequest/MessageDialogWithLink.java
@@ -12,14 +12,18 @@
 // ============================================================================
 package org.talend.designer.esb.components.ws.trestrequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
@@ -33,6 +37,12 @@ public class MessageDialogWithLink extends MessageDialog {
 
     private String linkUrl;
 
+    private boolean askForEndpoint = false;
+
+    private IPreferenceStore prefs;
+
+    private String messageWithLink;
+
     /**
      * DOC dsergent MessageDialogWithLink constructor comment.
      * 
@@ -45,25 +55,77 @@ public class MessageDialogWithLink extends MessageDialog {
      * @param defaultIndex
      */
     public MessageDialogWithLink(Shell parentShell, String dialogTitle, Image dialogTitleImage, String dialogMessage,
-            String linkUrl, int dialogImageType, String[] dialogButtonLabels, int defaultIndex) {
+            String messageWithLink, String linkUrl, int dialogImageType, String[] dialogButtonLabels, int defaultIndex,
+            boolean askForEndpoint) {
         super(parentShell, dialogTitle, dialogTitleImage, dialogMessage, dialogImageType, dialogButtonLabels, defaultIndex);
 
+        this.message = dialogMessage;
+        this.messageWithLink = messageWithLink;
         this.linkUrl = linkUrl;
+        this.askForEndpoint = askForEndpoint;
+
+        this.prefs = TRESTRequestPlugin.getDefault().getPreferenceStore();
     }
 
     @Override
     protected Control createMessageArea(Composite composite) {
+
+        Composite cpoMain = new Composite(composite, SWT.NONE);
+
+        GridLayout gdlCpoMain = new GridLayout(2, false);
+        cpoMain.setLayout(gdlCpoMain);
+
         Image image = getImage();
+
         if (image != null) {
-            imageLabel = new Label(composite, SWT.NULL);
+            imageLabel = new Label(cpoMain, SWT.NULL);
             image.setBackground(imageLabel.getBackground());
             imageLabel.setImage(image);
             GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.BEGINNING).applyTo(imageLabel);
         }
 
-        if (message != null) {
-            Link link = new Link(composite, getMessageLabelStyle());
-            link.setText(message);
+        Composite cpoRight = new Composite(cpoMain, SWT.NONE);
+        GridLayout gdlCpoRight = new GridLayout(1, false);
+        gdlCpoRight.verticalSpacing = 20;
+        cpoRight.setLayout(gdlCpoRight);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(cpoRight);
+
+        if (StringUtils.isNotBlank(message)) {
+
+            Label labelMessage = new Label(cpoRight, getMessageLabelStyle());
+            labelMessage.setText(message);
+            GridDataFactory.fillDefaults().align(SWT.FILL, SWT.BEGINNING).grab(true, false)
+                    .hint(convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH), SWT.DEFAULT)
+                    .applyTo(labelMessage);
+        }
+
+        if (askForEndpoint) {
+
+            boolean keepEndpointValue = prefs.getBoolean(TRESTRequestConstants.PREF_KEEP_ENDPOINT);
+
+            final Button chkKeepEndpoint = new Button(cpoRight, SWT.CHECK);
+            chkKeepEndpoint.setText("Keep existing endpoint configuration (do not override)");
+            chkKeepEndpoint.setSelection(keepEndpointValue);
+
+            GridDataFactory.fillDefaults().align(SWT.FILL, SWT.BEGINNING).grab(true, false)
+                    .hint(convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH), SWT.DEFAULT)
+                    .applyTo(chkKeepEndpoint);
+
+            chkKeepEndpoint.addSelectionListener(new SelectionAdapter() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    prefs.putValue(TRESTRequestConstants.PREF_KEEP_ENDPOINT, String.valueOf(chkKeepEndpoint.getSelection()));
+
+                }
+            });
+
+        }
+
+        if (StringUtils.isNotBlank(messageWithLink)) {
+
+            Link link = new Link(cpoRight, getMessageLabelStyle());
+            link.setText(messageWithLink);
             GridDataFactory.fillDefaults().align(SWT.FILL, SWT.BEGINNING).grab(true, false)
                     .hint(convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH), SWT.DEFAULT).applyTo(link);
 
@@ -75,17 +137,20 @@ public class MessageDialogWithLink extends MessageDialog {
                 }
             });
         }
+
         return composite;
     }
 
-    public static boolean openConfirm(Shell shell, String title, String messageWithLink, String linkUrl) {
-        return new MessageDialogWithLink(shell, title, null, messageWithLink, linkUrl, MessageDialog.CONFIRM,
-                new String[] { "OK", "Cancel" }, 0).open() == MessageDialog.OK;
+    public static boolean openConfirm(Shell shell, String title, String dialogMessage, String messageWithLink, String linkUrl,
+            boolean askForEndpoint) {
+        return new MessageDialogWithLink(shell, title, null, dialogMessage, messageWithLink, linkUrl, MessageDialog.CONFIRM,
+                new String[] { "OK", "Cancel" }, 0, askForEndpoint).open() == MessageDialog.OK;
     }
 
-    public static void openError(Shell shell, String title, String messageWithLink, String linkUrl) {
-        new MessageDialogWithLink(shell, title, null, messageWithLink, linkUrl, MessageDialog.ERROR, new String[] { "OK" }, 0)
-                .open();
+    public static void openError(Shell shell, String title, String dialogMessage, String messageWithLink, String linkUrl,
+            boolean askForEndpoint) {
+        new MessageDialogWithLink(shell, title, null, dialogMessage, messageWithLink, linkUrl, MessageDialog.ERROR,
+                new String[] { "OK" }, 0, askForEndpoint).open();
     }
 
 }

--- a/main/plugins/org.talend.designer.esb.components.ws.trestrequest/src/org/talend/designer/esb/components/ws/trestrequest/TRESTRequestConstants.java
+++ b/main/plugins/org.talend.designer.esb.components.ws.trestrequest/src/org/talend/designer/esb/components/ws/trestrequest/TRESTRequestConstants.java
@@ -2,6 +2,8 @@ package org.talend.designer.esb.components.ws.trestrequest;
 
 public interface TRESTRequestConstants {
 
+    String PREF_KEEP_ENDPOINT = "PREF_KEEP_ENDPOINT";
+
     String REST_ENDPOINT = "REST_ENDPOINT"; // scheme + host + port
 
     String PATH = "PATH"; // endpoint

--- a/main/plugins/org.talend.designer.esb.components.ws.trestrequest/src/org/talend/designer/esb/components/ws/trestrequest/TRESTRequestNode.java
+++ b/main/plugins/org.talend.designer.esb.components.ws.trestrequest/src/org/talend/designer/esb/components/ws/trestrequest/TRESTRequestNode.java
@@ -118,7 +118,7 @@ public class TRESTRequestNode extends AbstractExternalNode {
                     case SUCCESS:
                         if (crestNodeAdapter.isNodeToDefaultValues()) {
                             if (MessageDialogWithLink.openConfirm(shell, "Confirm component initialization",
-                                    "Initialize component?")) {
+                                    "Initialize component?", "", "", false)) {
                                 crestNodeAdapter.setNodeSetting(oasManager);
                                 return SWT.OK;
                             } else {
@@ -126,7 +126,8 @@ public class TRESTRequestNode extends AbstractExternalNode {
                             }
                         } else {
                             if (MessageDialogWithLink.openConfirm(shell, "Confirm component initialization",
-                                    "Initialize component?\n\nYour existing endpoint, API mappings and documentation will be overridden.")) {
+                                    "Initialize component?\n\nYour existing endpoint, API mappings and documentation will be overridden.",
+                                    "", "", crestNodeAdapter.isEndpointNotNull())) {
                                 crestNodeAdapter.setNodeSetting(oasManager);
                                 return SWT.OK;
                             } else {
@@ -135,8 +136,9 @@ public class TRESTRequestNode extends AbstractExternalNode {
                         }
                     case SUCCESS_WITH_WARNINGS:
                         boolean confirm = MessageDialogWithLink.openConfirm(shell, "Confirm component initialization",
-                                "Initialize component?\nYour existing endpoint, API mappings and documentation will be overridden.\n\nIf some parts seem missing in your initialized component, please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
-                                "https://studio.restlet.com");
+                                "Initialize component?\n\nYour existing endpoint, API mappings and documentation will be overridden.",
+                                "If some parts seem missing in your initialized component, please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
+                                "https://studio.restlet.com", crestNodeAdapter.isEndpointNotNull());
 
                         if (confirm) {
                             crestNodeAdapter.setNodeSetting(oasManager);
@@ -146,8 +148,9 @@ public class TRESTRequestNode extends AbstractExternalNode {
                         }
                     case ERROR:
                         MessageDialogWithLink.openError(shell, "OAS/Swagger 2.0 import error",
-                                "We were unable to initialize your component from your OAS/Swagger 2.0 definition.\n\nPlease check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
-                                "https://studio.restlet.com");
+                                "We were unable to initialize your component from your OAS/Swagger 2.0 definition.",
+                                "Please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
+                                "https://studio.restlet.com", false);
                         return SWT.CANCEL;
                     default:
                         return SWT.CANCEL;
@@ -161,8 +164,9 @@ public class TRESTRequestNode extends AbstractExternalNode {
 
             } catch (TranslationException e) {
                 MessageDialogWithLink.openError(shell, "OAS/Swagger 2.0 import error",
-                        "We were unable to initialize your component from your OAS/Swagger 2.0 definition.\n\nPlease check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.",
-                        "https://studio.restlet.com");
+                        "We were unable to initialize your component from your OAS/Swagger 2.0 definition.",
+                        "Please check your OAS/Swagger 2.0 definition in <a>Restlet Studio</a>.", "https://studio.restlet.com",
+                        false);
                 return SWT.CANCEL;
             }
         } else {


### PR DESCRIPTION
TESB-21258 After swagger defintion import, tRESTRequest component did
not offer output flows as available outputs: fixed.

TESB-21070 Now, user can choose to keep the already configured endpoint
when importing a swagger definition (improvement to avoid overriding a
context value for example)