### PR TITLE
[TESB-21752] Cannot request successfully with cREST+SAML+Authorization

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.ws.consumer/plugin.xml
+++ b/main/plugins/org.talend.designer.esb.components.ws.consumer/plugin.xml
@@ -543,6 +543,11 @@
             id="wss4j-ws-security-policy-stax"
             uripath="platform:/plugin/org.talend.libraries.esb/lib/${tesb-wss4j-ws-security-policy-stax}"
             bundleID="" />
+        <libraryNeeded context="plugin:org.talend.libraries.esb"
+            name="${tesb-wss4j-bindings}"
+            id="wss4j-bindings"
+            uripath="platform:/plugin/org.talend.libraries.esb/lib/${tesb-wss4j-bindings}"
+            bundleID="" />
 
         <libraryNeededGroup
                 description="cxf-rt-ws-security"


### PR DESCRIPTION
Adding wss4j-bindings library to microservices with security enabled.  
wss4j-bindings libarary is  included into "security-common" modules group, but there is no declaration of library with such id, therefore probably it is not included into MS jar.