### PR TITLE
fix(TESB-21702) Fix route generation

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/runprocess/maven/BundleJavaProcessor.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/runprocess/maven/BundleJavaProcessor.java
@@ -18,10 +18,13 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.talend.camel.core.model.camelProperties.CamelProcessItem;
 import org.talend.camel.designer.ui.wizards.actions.JavaCamelJobScriptsExportWSAction;
+import org.talend.commons.exception.ExceptionHandler;
 import org.talend.core.GlobalServiceRegister;
 import org.talend.core.model.process.IProcess;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.properties.Property;
+import org.talend.core.model.repository.IRepositoryObject;
+import org.talend.core.model.repository.RepositoryObject;
 import org.talend.core.repository.seeker.RepositorySeekerManager;
 import org.talend.core.runtime.process.TalendProcessArgumentConstant;
 import org.talend.core.runtime.process.TalendProcessOptionConstants;
@@ -169,42 +172,17 @@ public class BundleJavaProcessor extends MavenJavaProcessor {
      */
     @Override
     public void generatePom(int option) {
-
-        if (BitwiseOptionUtils.containOption(option, TalendProcessOptionConstants.GENERATE_POM_ONLY)) {
-
-            ProcessItem processItem = (ProcessItem) getProperty().getItem();
-
-            Object bt = processItem.getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
-
-            if (processItem instanceof CamelProcessItem) {
-                CamelProcessItem camelProcessItem = (CamelProcessItem) processItem;
-                if (bt == null || "ROUTE".equals(bt)) {
-                    camelProcessItem.setExportMicroService(false);
-                } else {
-                    camelProcessItem.setExportMicroService(true);
-                }
-            }
-
-            if (!BitwiseOptionUtils.containOption(option, TalendProcessOptionConstants.GENERATE_NO_CODEGEN)) {
-                try {
-                    ProcessorUtilities.generateCode(processItem, getContext().getName(), true, false);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-
-        } else {
-            super.generatePom(option);
-        }
+        super.generatePom(option);
         try {
-            IRepositoryNode repositoryNode = RepositorySeekerManager.getInstance().searchRepoViewNode(getProperty().getId(),
-                    false);
+            IRepositoryObject repositoryObject = new RepositoryObject(getProperty());
 
-            IRunnableWithProgress action = new JavaCamelJobScriptsExportWSAction(repositoryNode, getProperty().getVersion(), "",
+            RepositorySeekerManager.getInstance().searchRepoViewNode(getProperty().getId(), false);
+
+            IRunnableWithProgress action = new JavaCamelJobScriptsExportWSAction(repositoryObject, getProperty().getVersion(), "",
                     false);
             action.run(new NullProgressMonitor());
         } catch (Exception e) {
-            e.printStackTrace();
+            ExceptionHandler.process(e);
         }
     }
 }

--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWithMavenAction.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWithMavenAction.java
@@ -27,6 +27,8 @@ import org.talend.core.repository.constants.FileConstants;
 import org.talend.designer.publish.core.models.FeaturesModel;
 import org.talend.designer.runprocess.IProcessor;
 import org.talend.repository.model.IRepositoryNode;
+import org.talend.repository.model.RepositoryNode;
+import org.talend.repository.model.IRepositoryNode.ENodeType;
 import org.talend.repository.ui.wizards.exportjob.action.JobExportAction;
 import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JobScriptsManager;
 import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JobScriptsManager.ExportChoice;
@@ -65,7 +67,8 @@ public class JavaCamelJobScriptsExportWithMavenAction extends JavaCamelJobScript
     private void exportMavenResources(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
         scriptsManager.setMultiNodes(false);
         scriptsManager.setDestinationPath(destinationPath);
-        JobExportAction action = new JobExportAction(Collections.singletonList(routeNode), version, bundleVersion, scriptsManager,
+        RepositoryNode node = new RepositoryNode(routeObject, null, ENodeType.REPOSITORY_ELEMENT);
+        JobExportAction action = new JobExportAction(Collections.singletonList(node), version, bundleVersion, scriptsManager,
                 getTempDir(), "Route"); //$NON-NLS-1$
         action.run(monitor);
     }
@@ -75,8 +78,8 @@ public class JavaCamelJobScriptsExportWithMavenAction extends JavaCamelJobScript
     }
 
     private Collection<String> getReferenceRoutlets() {
-        ProcessItem routeProcess = (ProcessItem) routeNode.getObject().getProperty().getItem();
-        String routeName = routeNode.getObject().getProperty().getDisplayName();
+        ProcessItem routeProcess = getProcessItem();
+        String routeName = routeObject.getProperty().getDisplayName();
         Set<String> routelets = new HashSet<>();
         try {
             exportAllReferenceRoutelets(routeName, routeProcess, routelets);


### PR DESCRIPTION
Remove any generation from the generatePom code, as it makes no sense to generate any code during this part. (old code when the route were generating full code in the pom i think)

Changes the functions of export to use only IRepositoryViewObject instead of the "RepositoryNode" which is normally only using the repository view (with GUI)