### PR TITLE
fix(TESB-21796): Enforce synchronized build type flags on route build.

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/RouteProcessConvertServiceImpl.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/RouteProcessConvertServiceImpl.java
@@ -31,7 +31,20 @@ public class RouteProcessConvertServiceImpl implements IProcessConvertService {
             RouteProcess process = new RouteProcess(item.getProperty());
             if (item instanceof CamelProcessItemImpl) {
                 CamelProcessItemImpl camelProcessItemImpl = (CamelProcessItemImpl) item;
-                if (camelProcessItemImpl.isExportMicroService()) {
+                // FIXME: revisit the duplication of information between BUILD_TYPE and
+                // camelProcessItemImpl.isExportMicroService(). It is synchronized here
+                // as it gets out of sync with changes to BUILD_TYPE.
+                String bt = (String) item.getProperty().getAdditionalProperties().get("BUILD_TYPE");
+                boolean isMS;
+                if (bt == null) {
+                	isMS = camelProcessItemImpl.isExportMicroService();
+                } else {
+                	isMS = bt.indexOf("MICROSERVICE") >= 0;
+                	if (camelProcessItemImpl.isExportMicroService() != isMS) {
+                		camelProcessItemImpl.setExportMicroService(isMS);
+                	}
+                }
+                if (isMS) {
                     process = new MicroServiceProcess(item.getProperty());
                 }
             }


### PR DESCRIPTION
Currently, we have BUILD_TYPE and "camelProcessImpl.isExportMicroService()" controlling route KAR vs. microservice build. If the build type is changed in Studio in the "deployment composite", the CamelProcessImpl does not get updated, and there is no easy way to get this ensured. Therefore, the present fix ensures this update during route build.