### PR TITLE
TESB-21798 Initialize of Local Talend Runtime leads to a timeout error

### DIFF
--- a/main/plugins/org.talend.designer.esb.runcontainer/src/main/java/org/talend/designer/esb/runcontainer/preferences/RunContainerPreferencePage.java
+++ b/main/plugins/org.talend.designer.esb.runcontainer/src/main/java/org/talend/designer/esb/runcontainer/preferences/RunContainerPreferencePage.java
@@ -128,7 +128,7 @@ public class RunContainerPreferencePage extends FieldLayoutPreferencePage implem
         groupServer.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         groupServer.setLayout(new GridLayout(2, false));
 
-        compositeServerBody = new Composite(groupServer, SWT.BORDER);
+        compositeServerBody = new Composite(groupServer, SWT.NONE);
         compositeServerBody.setLayout(gridLayoutDefault);
         compositeServerBody.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 

--- a/main/plugins/org.talend.designer.esb.runcontainer/src/main/java/org/talend/designer/esb/runcontainer/ui/progress/StartRuntimeProgress.java
+++ b/main/plugins/org.talend.designer.esb.runcontainer/src/main/java/org/talend/designer/esb/runcontainer/ui/progress/StartRuntimeProgress.java
@@ -35,7 +35,7 @@ public class StartRuntimeProgress extends RuntimeProgress {
 
     @Override
     public void run(IProgressMonitor parentMonitor) throws InvocationTargetException, InterruptedException {
-        SubMonitor subMonitor = SubMonitor.convert(parentMonitor, 10);
+        SubMonitor subMonitor = SubMonitor.convert(parentMonitor, 100);
         subMonitor.setTaskName(RunContainerMessages.getString("StartRuntimeAction.Starting")); //$NON-NLS-1$
         if (!checkRunning()) {
             try {
@@ -44,7 +44,7 @@ public class StartRuntimeProgress extends RuntimeProgress {
                         store.getString(RunContainerPreferenceInitializer.P_ESB_RUNTIME_LOCATION));
                 int i = 0;
                 String dot = "."; //$NON-NLS-1$
-                while (JMXUtil.createJMXconnection() == null && ++i < 11 && !subMonitor.isCanceled() && proc.isAlive()) {
+                while (JMXUtil.createJMXconnection() == null && ++i < 101 && !subMonitor.isCanceled() && proc.isAlive()) {
                     subMonitor.subTask(RunContainerMessages.getString("StartRuntimeAction.Try") + dot); //$NON-NLS-1$
                     dot += "."; //$NON-NLS-1$
                     subMonitor.worked(1);


### PR DESCRIPTION
By increasing the number of attempts to reach the runtime, chances to get the error message will be very low. 

Commit contains also removal of useless border in Runtime config preferences page.

