### PR TITLE
TESB-21832 Problems with job/route exec. with local runtime in Studio

### DIFF
--- a/main/plugins/org.talend.designer.esb.runcontainer/src/main/java/org/talend/designer/esb/runcontainer/core/LocalESBRunContainerService.java
+++ b/main/plugins/org.talend.designer.esb.runcontainer/src/main/java/org/talend/designer/esb/runcontainer/core/LocalESBRunContainerService.java
@@ -16,8 +16,10 @@ import javax.management.MBeanServerConnection;
 
 import org.talend.core.model.components.ComponentCategory;
 import org.talend.core.model.process.IProcess;
+import org.talend.core.model.process.IProcess2;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.properties.Property;
+import org.talend.core.runtime.process.TalendProcessArgumentConstant;
 import org.talend.designer.esb.runcontainer.preferences.RunContainerPreferenceInitializer;
 import org.talend.designer.esb.runcontainer.process.RunContainerProcessor;
 import org.talend.designer.esb.runcontainer.util.JMXUtil;
@@ -30,13 +32,6 @@ import org.talend.repository.utils.EmfModelUtils;
  * TESB-18750, Locally ESB runtime server service
  */
 public class LocalESBRunContainerService implements IESBRunContainerService {
-
-    private boolean enableRuntime;
-
-    @Override
-    public void enableRuntime(boolean inRuntime) {
-        this.enableRuntime = inRuntime;
-    }
 
     @Override
     public boolean isRuntimeEnable() {
@@ -55,18 +50,37 @@ public class LocalESBRunContainerService implements IESBRunContainerService {
      */
     @Override
     public JavaProcessor createJavaProcessor(IProcess process, Property property, boolean filenameFromLabel) {
+
         if (ESBRunContainerPlugin.getDefault().getPreferenceStore().getBoolean(RunContainerPreferenceInitializer.P_ESB_IN_OSGI)) {
             if (ComponentCategory.CATEGORY_4_CAMEL.getName().equals(process.getComponentsType())) {
-                if (process.getClass().getName().endsWith("MicroServiceProcess")) {
+
+                if (process instanceof IProcess2 && "ROUTE_MICROSERVICE".equals(
+                        ((IProcess2) process).getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
+
                     return null;
+
                 } else {
+
                     return new RunContainerProcessor(process, property, filenameFromLabel);
+
                 }
             } else if (ComponentCategory.CATEGORY_4_DI.getName().equals(process.getComponentsType())) {
-                String[] esbComponents = { "tESBProviderRequest", "tRESTClient", "tRESTRequest", "tRESTResponse",
-                        "tESBConsumer", "tESBProviderFault", "tESBProviderRequest", "tESBProviderResponse" };
+                String[] esbComponents = { "tESBProviderRequest", "tRESTClient", "tRESTRequest", "tRESTResponse", "tESBConsumer",
+                        "tESBProviderFault", "tESBProviderRequest", "tESBProviderResponse" };
                 if (EmfModelUtils.getComponentByName((ProcessItem) property.getItem(), esbComponents) != null) {
-                    return new RunContainerProcessor(process, property, filenameFromLabel);
+
+                    if (process instanceof IProcess2 && ("REST_MS".equals(
+                            ((IProcess2) process).getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))
+                            || "STANDALONE".equals(((IProcess2) process).getAdditionalProperties()
+                                    .get(TalendProcessArgumentConstant.ARG_BUILD_TYPE)))) {
+
+                        return null;
+
+                    } else {
+
+                        return new RunContainerProcessor(process, property, filenameFromLabel);
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
Local runtime for Studio job/routes execution should not be used in some
cases: build type has to be checked to define the best execution
processor. As execution processor must change when build type is updated
in deployment tab, processor can not be persisted anymore.

Tests for jobs/routes build types have been updated to get the appropriate processor.