### PR TITLE
fix(TESB-22400): Ensure unique execution ids for embedded job installation.

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/build/CreateMavenBundlePom.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/build/CreateMavenBundlePom.java
@@ -121,9 +121,10 @@ public class CreateMavenBundlePom extends CreateMavenJobPom {
 
             Set<JobInfo> subjobs = getJobProcessor().getBuildChildrenJobs();
             if (subjobs != null && !subjobs.isEmpty()) {
+            	int ndx = 0;
                 for (JobInfo subjob : subjobs) {
                     if (isRoutelet(subjob) || isJob(subjob) ) {
-                        fmBuild.addPlugin(addFileInstallPlugin(subjob));
+                        fmBuild.addPlugin(addFileInstallPlugin(subjob, ndx++));
                     }
                 }
             }
@@ -463,7 +464,7 @@ public class CreateMavenBundlePom extends CreateMavenJobPom {
 
     }
 
-    private Plugin addFileInstallPlugin(JobInfo job) {
+    private Plugin addFileInstallPlugin(JobInfo job, int ndx) {
         Plugin plugin = new Plugin();
 
         plugin.setGroupId("org.apache.maven.plugins");
@@ -506,7 +507,7 @@ public class CreateMavenBundlePom extends CreateMavenJobPom {
 
         List<PluginExecution> pluginExecutions = new ArrayList<PluginExecution>();
         PluginExecution pluginExecution = new PluginExecution();
-        pluginExecution.setId("install-jar-lib");
+        pluginExecution.setId("install-jar-lib-" + ndx);
         pluginExecution.addGoal("install-file");
         pluginExecution.setPhase("validate");
 


### PR DESCRIPTION
The present fix makes sure that invocations of the maven-install-plugin for embedded jobs get unique execution ids in the feature POM.