### PR TITLE
TESB-21643 Update REST API Swagger doc to reflect job settings

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.rs.provider/additional/header_additional_talendesb_rest.javajet
+++ b/main/plugins/org.talend.designer.esb.components.rs.provider/additional/header_additional_talendesb_rest.javajet
@@ -1063,7 +1063,7 @@ if (exposeSwagger) {
 				}
 				if (exposeSwagger) {
 					%>
-					@io.swagger.annotations.ApiParam(value="<%=param.getName()%>", required = true)<%
+					@io.swagger.annotations.ApiParam(value="<%=param.getName()%>", required = <%=param.isNullable()%>)<%
 				}
 
 				if (param.getDefaultValue() != null && param.getDefaultValue().length() > 0) {


### PR DESCRIPTION
REST operation parameters should not always be marked as required=true.
Parameters marked as 'Nullable' in job REST component must be considered
as required=false in swagger documentation.