### PR TITLE
Fix compile issue for code generation of cKafka with security

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/components/cKafka/cKafka_main.javajet
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/components/cKafka/cKafka_main.javajet
@@ -87,14 +87,13 @@ imports="
 
     String sslTrustStorePasswordField = "__SSL_TRUSTSTORE_PASSWORD__";
     if (!"\"\"".equals(ElementParameterParser.getValue(node, sslTrustStorePasswordField).trim())) {
-        %>
-        <%if (ElementParameterParser.canEncrypt(node, sslTrustStorePasswordField)) {%> 
-            final String decryptedSSLTrustStorePassword = routines.system.PasswordEncryptUtil.decryptPassword(<%=ElementParameterParser.getEncryptedValue(node, sslTrustStorePasswordField)%>);
-        <%} else {%>
-            final String decryptedSSLTrustStorePassword = <%=ElementParameterParser.getValue(node, sslTrustStorePasswordField)%>; 
-        <%}%>
-        <%
-        builder.addParam("sslTruststorePassword", "decryptedSSLTrustStorePassword");
+
+        if (ElementParameterParser.canEncrypt(node, sslTrustStorePasswordField)) {
+            builder.addParam("sslTruststorePassword", "routines.system.PasswordEncryptUtil.decryptPassword("+ElementParameterParser.getEncryptedValue(node, sslTrustStorePasswordField)+")");
+        } else {
+            builder.addParam("sslTruststorePassword", ElementParameterParser.getValue(node, sslTrustStorePasswordField));
+        }
+
     }
 
     String sslTruststoreLocation = ElementParameterParser.getValue(node, "__SSL_TRUSTSTORE_LOCATION__").trim();


### PR DESCRIPTION
I changed the code to put the code to decrypt the password directly into the Kafka URL string instead of in a separate variable. This change prevents the method chain from being broken by a variable declaration