### PR TITLE
[TESB-23646] Bug in cREST producer: response inputstream is closed

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
@@ -201,10 +201,22 @@ imports="
 			public java.lang.Object unmarshal(org.apache.camel.Exchange exchange, java.io.InputStream is) throws java.lang.Exception {
 		   	java.lang.Object b = exchange.getOut().getBody();
 		   	if(b instanceof org.apache.cxf.jaxrs.impl.ResponseImpl){
-		   		org.apache.cxf.jaxrs.impl.ResponseImpl r = (org.apache.cxf.jaxrs.impl.ResponseImpl)b;
+				org.apache.cxf.jaxrs.impl.ResponseImpl r = (org.apache.cxf.jaxrs.impl.ResponseImpl)b;
 		   		if ("javax.ws.rs.core.Response.class".equalsIgnoreCase("<%=responseClass%>")) {
 		   			return <%=responseClass%>.cast(r);
-		   		}
+                } else if ("<%=responseClass%>".equalsIgnoreCase("java.io.InputStream.class")) {
+                    return new java.util.Iterator() {
+                        @Override
+                        public boolean hasNext() {
+                            return true;
+                        }
+
+                        @Override
+                        public Object next() {
+                            return is;
+                        }
+                    };
+                }
 		   		int status = r.getStatus();
 		   		if ((status < 200 || status == 204) && r.getLength() <= 0 || status >= 300) {
 		   			return null;
@@ -217,5 +229,16 @@ imports="
 					throws Exception {}
 		})
 <%
+        if (responseClass.equalsIgnoreCase("java.io.InputStream.class")) {
+%>
+        .process(new org.apache.camel.Processor() {
+            public void process(org.apache.camel.Exchange exchange) {
+                if (exchange.getIn().getBody() instanceof java.util.Iterator) {
+                    exchange.getIn().setBody(((java.util.Iterator)exchange.getIn().getBody()).next());
+                }
+            }
+        })
+<%
+        }
 	}
 %>

--- a/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
@@ -15,15 +15,15 @@ imports="
 %>
 
 <%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
+    CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
 
-	INode node = (INode)codeGenArgument.getArgument();
+    INode node = (INode)codeGenArgument.getArgument();
 
-	IProcess process = node.getProcess();
+    IProcess process = node.getProcess();
 
-	String cid = node.getUniqueName();
+    String cid = node.getUniqueName();
 
-	NodeParamsHelper paramsHelper = new NodeParamsHelper(node);
+    NodeParamsHelper paramsHelper = new NodeParamsHelper(node);
 
     boolean isProvider = node.getIncomingConnections().isEmpty();
 
@@ -31,20 +31,20 @@ imports="
                                               && "OIDC".equals(ElementParameterParser.getValue(node, "__SECURITY_TYPE__"))
                                               && !node.getIncomingConnections().isEmpty();
 
-	CamelEndpointBuilder builder = CamelEndpointBuilder.getBuilder();
-	CamelEndpointBuilder builderRT = CamelEndpointBuilder.getBuilder();
-	builder.useComponentColon(false);
-	builder.useDoubleSlash(false);
-	builderRT.useComponentColon(false);
-	builderRT.useDoubleSlash(false);
+    CamelEndpointBuilder builder = CamelEndpointBuilder.getBuilder();
+    CamelEndpointBuilder builderRT = CamelEndpointBuilder.getBuilder();
+    builder.useComponentColon(false);
+    builder.useDoubleSlash(false);
+    builderRT.useComponentColon(false);
+    builderRT.useDoubleSlash(false);
 
 
 %>
 
 <%
-	String endpointUrlRT = ElementParameterParser.getValue(node, "__URL__");
+    String endpointUrlRT = ElementParameterParser.getValue(node, "__URL__");
 
-	String endpointUrlStudio = endpointUrlRT;
+    String endpointUrlStudio = endpointUrlRT;
 
     if(isProvider) {
 
@@ -53,9 +53,9 @@ imports="
                 endpointUrlRT = endpointUrlRT.replaceFirst("/services","");
             }
             if (!endpointUrlRT.startsWith("/")) {
-            	if(!endpointUrlRT.startsWith("context.")){
-            		endpointUrlRT = endpointUrlRT;
-            	}
+                if(!endpointUrlRT.startsWith("context.")){
+                    endpointUrlRT = endpointUrlRT;
+                }
             }
         }
         String defaultUri = (String) System.getProperties().get("restServiceDefaultUri");
@@ -63,7 +63,7 @@ imports="
             defaultUri = defaultUri.substring(0, defaultUri.length()-1);
         }
         if (null == defaultUri || defaultUri.trim().isEmpty() || !defaultUri.contains("://")) {
-        	defaultUri = "http://127.0.0.1:8090";
+            defaultUri = "http://127.0.0.1:8090";
         }
         String defaultEndpointUrl = "\""+defaultUri+"\"";
 
@@ -79,23 +79,23 @@ imports="
             }
         }
 
-		boolean isTestContainer = ProcessUtils.isTestContainer(process);
+        boolean isTestContainer = ProcessUtils.isTestContainer(process);
 
-		String className = isTestContainer ? process.getName() + "Test" : process.getName();
+        String className = isTestContainer ? process.getName() + "Test" : process.getName();
 
-		String routeFolderName = "";
-	    IProcess baseProcess = ProcessUtils.getTestContainerBaseProcess(process);
+        String routeFolderName = "";
+        IProcess baseProcess = ProcessUtils.getTestContainerBaseProcess(process);
 
-	    if (baseProcess != null) {
-	        routeFolderName = JavaResourcesHelper.getJobFolderName(baseProcess.getName(), baseProcess.getVersion()) + ".";
-	    }
+        if (baseProcess != null) {
+            routeFolderName = JavaResourcesHelper.getJobFolderName(baseProcess.getName(), baseProcess.getVersion()) + ".";
+        }
 
-	    routeFolderName = routeFolderName + JavaResourcesHelper.getJobFolderName(process.getName(), process.getVersion());
+        routeFolderName = routeFolderName + JavaResourcesHelper.getJobFolderName(process.getName(), process.getVersion());
 
-	    String packageName = codeGenArgument.getCurrentProjectName().toLowerCase() + "." + routeFolderName;
+        String packageName = codeGenArgument.getCurrentProjectName().toLowerCase() + "." + routeFolderName;
 
-		builder.addParam("resourceClasses", "\"" + packageName + "." + className + "$Service_" + cid + "\"");
-		builderRT.addParam("resourceClasses", "\"" + packageName + "." + className + "$Service_" + cid + "\"");
+        builder.addParam("resourceClasses", "\"" + packageName + "." + className + "$Service_" + cid + "\"");
+        builderRT.addParam("resourceClasses", "\"" + packageName + "." + className + "$Service_" + cid + "\"");
 
     } else {
         if ("true".equals(ElementParameterParser.getValue(node, "__SERVICE_LOCATOR__"))) {
@@ -130,106 +130,112 @@ imports="
         String argName = map.get("NAME").trim();
         String argValue = map.get("VALUE").trim();
         if(argName.startsWith("\"") && argName.endsWith("\"") && argName.length() >= 2) {
-			argName = argName.substring(1, argName.length() - 1);
-		}
-		builder.addParam(argName, argValue);
-		builderRT.addParam(argName, argValue);
+            argName = argName.substring(1, argName.length() - 1);
+        }
+        builder.addParam(argName, argValue);
+        builderRT.addParam(argName, argValue);
     }
 
-   	builder.setComponent("cxfrs://");
-	builderRT.setComponent("cxfrs://");
+    builder.setComponent("cxfrs://");
+    builderRT.setComponent("cxfrs://");
 
-	if("".equals(endpointUrlStudio) || endpointUrlStudio == null || "\"\"".equals(endpointUrlStudio)){
-		builder.appendPath("\"/\"");
-	}else{
-		builder.appendPath(endpointUrlStudio);
-	}
+    if("".equals(endpointUrlStudio) || endpointUrlStudio == null || "\"\"".equals(endpointUrlStudio)){
+        builder.appendPath("\"/\"");
+    }else{
+        builder.appendPath(endpointUrlStudio);
+    }
 
-	if("".equals(endpointUrlRT) || endpointUrlRT == null || "\"\"".equals(endpointUrlRT)){
-		builderRT.appendPath("\"/\"");
-	}else{
-		builderRT.appendPath(endpointUrlRT);
-	}
+    if("".equals(endpointUrlRT) || endpointUrlRT == null || "\"\"".equals(endpointUrlRT)){
+        builderRT.appendPath("\"/\"");
+    }else{
+        builderRT.appendPath(endpointUrlRT);
+    }
 
     String uriRT = builderRT.build();
 
     String uriStudio = builder.build();
 
     String responseClass = "javax.ws.rs.core.Response.class";
-	if (node.getIncomingConnections().isEmpty()) {
+    if (node.getIncomingConnections().isEmpty()) {
 %>
-		from(inOSGi || inMS ?<%=uriRT%>:<%=uriStudio%>)
-		.process(new org.apache.camel.Processor() {
-				public void process(org.apache.camel.Exchange exchange) throws Exception {
-					org.apache.camel.Message inMessage = exchange.getIn();
-					inMessage.setHeader("http_query",
-						org.apache.cxf.jaxrs.utils.JAXRSUtils.getStructuredParams((String) inMessage.getHeader(org.apache.camel.Exchange.HTTP_QUERY), "&", false, false));
-				}
-			})
+        from(inOSGi || inMS ?<%=uriRT%>:<%=uriStudio%>)
+        .process(new org.apache.camel.Processor() {
+                public void process(org.apache.camel.Exchange exchange) throws Exception {
+                    org.apache.camel.Message inMessage = exchange.getIn();
+                    inMessage.setHeader("http_query",
+                        org.apache.cxf.jaxrs.utils.JAXRSUtils.getStructuredParams((String) inMessage.getHeader(org.apache.camel.Exchange.HTTP_QUERY), "&", false, false));
+                }
+            })
 <%
-	} else {
+    } else {
 
-		if ("MANUAL".equals(ElementParameterParser.getValue(node, "__SERVICE_TYPE__"))) {
-			String acceptType = paramsHelper.getVisibleStringParam("__ACCEPT_TYPE__");
-			String responseBean = paramsHelper.getVisibleStringParam("__RESPONSE_BEAN__");
-			responseClass = "*/*".equals(acceptType) ? "String.class" : "org.w3c.dom.Document.class";
-			responseClass = responseBean == null || responseBean.isEmpty() ? responseClass : responseBean + ".class";
-			String contentType = paramsHelper.getVisibleStringParam("__CONTENT_TYPE__");
+        if ("MANUAL".equals(ElementParameterParser.getValue(node, "__SERVICE_TYPE__"))) {
+            String acceptType = paramsHelper.getVisibleStringParam("__ACCEPT_TYPE__");
+            String responseBean = paramsHelper.getVisibleStringParam("__RESPONSE_BEAN__");
+            responseClass = "*/*".equals(acceptType) ? "String.class" : "org.w3c.dom.Document.class";
+            responseClass = responseBean == null || responseBean.isEmpty() ? responseClass : responseBean + ".class";
+            String contentType = paramsHelper.getVisibleStringParam("__CONTENT_TYPE__");
 %>
-		.setHeader(org.apache.camel.Exchange.HTTP_PATH, <%=ElementParameterParser.getValue(node, "__PATH__")%>)
-		.setHeader(org.apache.camel.Exchange.HTTP_METHOD, constant("<%=ElementParameterParser.getValue(node, "__HTTP_METHOD__")%>"))
+        .setHeader(org.apache.camel.Exchange.HTTP_PATH, <%=ElementParameterParser.getValue(node, "__PATH__")%>)
+        .setHeader(org.apache.camel.Exchange.HTTP_METHOD, constant("<%=ElementParameterParser.getValue(node, "__HTTP_METHOD__")%>"))
 <% if (!acceptType.isEmpty()) { %>
-		.setHeader(org.apache.camel.Exchange.ACCEPT_CONTENT_TYPE, constant("<%=acceptType%>"))
+        .setHeader(org.apache.camel.Exchange.ACCEPT_CONTENT_TYPE, constant("<%=acceptType%>"))
 <% } %>
 <% if (!contentType.isEmpty()) { %>
-		.setHeader(org.apache.camel.Exchange.CONTENT_TYPE, constant("<%=contentType%>"))
+        .setHeader(org.apache.camel.Exchange.CONTENT_TYPE, constant("<%=contentType%>"))
 <% }
 } else { // RESOURCECLASS
 %>
-		.setHeader(org.apache.camel.component.cxf.common.message.CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, constant(Boolean.FALSE))
-		.setHeader(org.apache.camel.component.cxf.common.message.CxfConstants.OPERATION_NAME, <%=ElementParameterParser.getValue(node, "__RESOURCE_OPERATION__")%>)
+        .setHeader(org.apache.camel.component.cxf.common.message.CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, constant(Boolean.FALSE))
+        .setHeader(org.apache.camel.component.cxf.common.message.CxfConstants.OPERATION_NAME, <%=ElementParameterParser.getValue(node, "__RESOURCE_OPERATION__")%>)
 <% } %>
 <% if (paramsHelper.getBoolParam("__ENABLE_CORRELATION__")) { %>
-		.process(new org.apache.camel.Processor() {
-				public void process(org.apache.camel.Exchange exchange) throws Exception {
-					correlationIDCallbackHandler_<%=cid%>.setCorrelationId(simple(<%=paramsHelper.getVisibleStringParam("__CORRELATION_VALUE__")%>).evaluate(exchange, String.class));
-				}
-			})
+        .process(new org.apache.camel.Processor() {
+                public void process(org.apache.camel.Exchange exchange) throws Exception {
+                    correlationIDCallbackHandler_<%=cid%>.setCorrelationId(simple(<%=paramsHelper.getVisibleStringParam("__CORRELATION_VALUE__")%>).evaluate(exchange, String.class));
+                }
+            })
 <% } %>
-		.inOut(inOSGi?<%=uriRT%>:<%=uriStudio%>)
-		.unmarshal(new  org.apache.camel.spi.DataFormat() {
-			public java.lang.Object unmarshal(org.apache.camel.Exchange exchange, java.io.InputStream is) throws java.lang.Exception {
-		   	java.lang.Object b = exchange.getOut().getBody();
-		   	if(b instanceof org.apache.cxf.jaxrs.impl.ResponseImpl){
-				org.apache.cxf.jaxrs.impl.ResponseImpl r = (org.apache.cxf.jaxrs.impl.ResponseImpl)b;
-		   		if ("javax.ws.rs.core.Response.class".equalsIgnoreCase("<%=responseClass%>")) {
-		   			return <%=responseClass%>.cast(r);
-                } else if ("<%=responseClass%>".equalsIgnoreCase("java.io.InputStream.class")) {
+        .inOut(inOSGi?<%=uriRT%>:<%=uriStudio%>)
+        .unmarshal(new  org.apache.camel.spi.DataFormat() {
+            public java.lang.Object unmarshal(org.apache.camel.Exchange exchange, java.io.InputStream is) throws java.lang.Exception {
+            java.lang.Object b = exchange.getOut().getBody();
+            if (b instanceof org.apache.cxf.jaxrs.impl.ResponseImpl) {
+                org.apache.cxf.jaxrs.impl.ResponseImpl r = (org.apache.cxf.jaxrs.impl.ResponseImpl)b;
+<%  if ("javax.ws.rs.core.Response.class".equalsIgnoreCase(responseClass)) { %>
+                    return <%=responseClass%>.cast(r);
+<% } else if (responseClass.regionMatches(true, responseClass.length() - "InputStream.class".length(), "InputStream.class", 0, "InputStream.class".length())) { %>
+                int status = r.getStatus();
+                if ((status < 200 || status == 204) && r.getLength() <= 0 || status >= 300) {
+                    return null;
+                }
                     return new java.util.Iterator() {
+                        private boolean next = true;
                         @Override
                         public boolean hasNext() {
-                            return true;
+                            return next;
                         }
-
                         @Override
                         public Object next() {
+                            next = false;
                             return is;
                         }
                     };
+<% } else { %>
+                int status = r.getStatus();
+                if ((status < 200 || status == 204) && r.getLength() <= 0 || status >= 300) {
+                    return null;
                 }
-		   		int status = r.getStatus();
-		   		if ((status < 200 || status == 204) && r.getLength() <= 0 || status >= 300) {
-		   			return null;
-		   		}
-		   		return r.doReadEntity(<%=responseClass%>, <%=responseClass%>, new java.lang.annotation.Annotation[]{});
-		   	}
-		   	return b;
-		   }
-		   public void marshal(org.apache.camel.Exchange exchange, Object o, java.io.OutputStream os)
-					throws Exception {}
-		})
+                return r.doReadEntity(<%=responseClass%>, <%=responseClass%>, new java.lang.annotation.Annotation[]{});
+<% } %>
+            }
+            return b;
+        }
+        public void marshal(org.apache.camel.Exchange exchange, Object o, java.io.OutputStream os)
+                    throws Exception {}
+        })
 <%
-        if (responseClass.equalsIgnoreCase("java.io.InputStream.class")) {
+        if (responseClass.regionMatches(true, responseClass.length() - "InputStream.class".length(), "InputStream.class", 0, "InputStream.class".length())) {
 %>
         .process(new org.apache.camel.Processor() {
             public void process(org.apache.camel.Exchange exchange) {
@@ -240,5 +246,5 @@ imports="
         })
 <%
         }
-	}
+    }
 %>


### PR DESCRIPTION
Because unmarshal() method is present in the route, after unmarshall() call InputStream is closed by Camel. But, Camel does not close InputStream if if is wrapped by Iterator. The idea of the fix is to wrap InputStream with iterator, and later unwrap it back into InputStream.