### PR TITLE
TESB-24920 Default endpoint URI not added to endpoint with cRest

### DIFF
--- a/main/plugins/org.talend.camel.designer.codegen/resources/header_route.javajet
+++ b/main/plugins/org.talend.camel.designer.codegen/resources/header_route.javajet
@@ -1197,26 +1197,37 @@ final Map<String, String> contentTypes = new java.util.HashMap<String, String>()
         }
 %>
     public String getCXFRSEndpointAddress(String endpointUrl) {
-        if (inOSGi) {
+        
+		if (inOSGi) {
+		
             if (endpointUrl != null && !endpointUrl.trim().isEmpty() && !endpointUrl.contains("://")) {
+			
                 if (endpointUrl.startsWith("/services")) {
                     endpointUrl = endpointUrl.substring("/services".length());
                 }
+				
                 if (!endpointUrl.startsWith("/")) {
                     endpointUrl = '/' + endpointUrl;
                 }
             }
             return endpointUrl;
         }
+		
         String defaultEndpointUrl = "<%=defaultUri%>";
-        if (null == endpointUrl || endpointUrl.trim().isEmpty()) {
-            endpointUrl = defaultEndpointUrl;
+        
+		if (null == endpointUrl || endpointUrl.trim().isEmpty()) {
+            
+			endpointUrl = defaultEndpointUrl;
+			
         } else if (!endpointUrl.contains("://")) { // relative
-            if (endpointUrl.startsWith("/")) {
+            
+			if (endpointUrl.startsWith("/")) {
                 endpointUrl = endpointUrl.substring(1);
             }
-            endpointUrl = defaultEndpointUrl + endpointUrl;
+            
+			endpointUrl = defaultEndpointUrl + endpointUrl;
         }
+		
         return endpointUrl;
     }
 
@@ -2413,24 +2424,24 @@ if (isProvider) {
 
 				        String[] splittedEp = initialEp.split("\\+");
 
-				        if (splittedEp.length > 1) {
+				        if (splittedEp.length >= 1) {
 
 				            epForSwagger = "\"/services\"";
 
 				            for (String s : splittedEp) {
 				                s = s.trim();
-				                if (s.startsWith("\"") && s.endsWith("\"")) {
-				                    epForSwagger += " + " + s;
-				                } else {
-				                    epForSwagger += (" + " + s);
-				                }
+																 
+			                    epForSwagger += " + " + s;
+							
+													
+					 
 				            }
-				        } else {
+					
 
-				            if (initialEp.startsWith("\"") && initialEp.endsWith("\"")) {
-				                epForSwagger = "\"/services" + initialEp.substring(1, initialEp.length());
-				            }
-				        }
+																			 
+																							  
+						}
+			 
 
                         String swaggerTitle = className + " REST Application";
                         String swaggerDescription = "";
@@ -2445,8 +2456,9 @@ if (isProvider) {
                     %>
 
                     // swagger2Feature_<%=cid%>.setBasePath(getCXFRSEndpointAddress(<%=ElementParameterParser.getValue(node, "__URL__")%>));
+					
                     swagger2Feature_<%=cid%>.setBasePath(<%=epForSwagger%>);
-
+					
                     swagger2Feature_<%=cid%>.setUsePathBasedConfig(true);
                     swagger2Feature_<%=cid%>.setRunAsFilter(true);
                     swagger2Feature_<%=cid%>.setSwaggerUiMavenGroupAndArtifact("org.talend.esb/swagger-ui");
@@ -2556,7 +2568,7 @@ if (isProvider) {
                 <%}%>
 <%              } else {
 %>
-                factory_<%=cid%>.setAddress(<%=ElementParameterParser.getValue(node, "__URL__")%>);
+				factory_<%=cid%>.setAddress(<%=ElementParameterParser.getValue(node, "__URL__")%>);
 <%
                 }
 %>

--- a/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
@@ -43,40 +43,41 @@ imports="
 
 <%
     String endpointUrlRT = ElementParameterParser.getValue(node, "__URL__");
-
     String endpointUrlStudio = endpointUrlRT;
+	
+	String defaultUri = (String) System.getProperties().get("restServiceDefaultUri");
 
     if(isProvider) {
 
         if (endpointUrlRT != null && !endpointUrlRT.trim().isEmpty() && !endpointUrlRT.contains("://")) {
+		
             if (endpointUrlRT.startsWith("\"/services")) {
                 endpointUrlRT = endpointUrlRT.replaceFirst("/services","");
             }
-            if (!endpointUrlRT.startsWith("/")) {
-                if(!endpointUrlRT.startsWith("context.")){
-                    endpointUrlRT = endpointUrlRT;
-                }
-            }
+			
         }
-        String defaultUri = (String) System.getProperties().get("restServiceDefaultUri");
+        
         if (defaultUri != null && defaultUri.endsWith("/")) {
-            defaultUri = defaultUri.substring(0, defaultUri.length()-1);
+            defaultUri = defaultUri.substring(0, defaultUri.length() - 1);
         }
+		
         if (null == defaultUri || defaultUri.trim().isEmpty() || !defaultUri.contains("://")) {
             defaultUri = "http://127.0.0.1:8090";
         }
+		
         String defaultEndpointUrl = "\""+defaultUri+"\"";
 
         if (null == endpointUrlStudio || endpointUrlStudio.trim().isEmpty()) {
+		
             endpointUrlStudio = defaultEndpointUrl;
-        } else if (!endpointUrlStudio.contains("://")) { // relative
-            if (endpointUrlStudio.startsWith("/")) {
-                endpointUrlStudio = endpointUrlStudio.substring(1);
+			
+        } else if (!endpointUrlStudio.contains("://")) { // relative or context variable
+		
+            if (!endpointUrlStudio.contains("context.") && !endpointUrlStudio.startsWith("/")) {
+                endpointUrlStudio = "/" + endpointUrlStudio;
             }
 
-            if(!endpointUrlStudio.startsWith("context.")){
-            	endpointUrlStudio = defaultEndpointUrl + "+" + endpointUrlStudio;
-            }
+           	endpointUrlStudio = defaultEndpointUrl + "+" + endpointUrlStudio;
         }
 
         boolean isTestContainer = ProcessUtils.isTestContainer(process);
@@ -158,6 +159,7 @@ imports="
     String responseClass = "javax.ws.rs.core.Response.class";
     if (node.getIncomingConnections().isEmpty()) {
 %>
+
         from(inOSGi || inMS ?<%=uriRT%>:<%=uriStudio%>)
         .process(new org.apache.camel.Processor() {
                 public void process(org.apache.camel.Exchange exchange) throws Exception {


### PR DESCRIPTION
When using a context variable in cREST endpoint with a value such as
"/mypath", running the route in Studio will not work as default endpoint
defined in Studio preferences is not added as prefix to the complete
endpoint.