### PR TITLE
TESB-25260 "row1.payload can't be empty" error when calling SOAP Service with empty body

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.ws.provider/additional/header_additional_talendesb_wsprovider.javajet
+++ b/main/plugins/org.talend.designer.esb.components.ws.provider/additional/header_additional_talendesb_wsprovider.javajet
@@ -277,8 +277,11 @@ public class ESBProvider_<%=cid%> implements javax.xml.ws.Provider<javax.xml.tra
                 java.io.ByteArrayOutputStream os = new java.io.ByteArrayOutputStream();
                 org.apache.cxf.staxutils.StaxUtils.copy(request, os);
                 org.dom4j.Document requestDoc = new org.dom4j.io.SAXReader().read(new java.io.ByteArrayInputStream(os.toByteArray()));
-                esbRequest.put(ESBProviderCallback.REQUEST, requestDoc);
+            } else {
+		requestDoc = org.dom4j.DocumentHelper.createDocument();
+                requestDoc.addElement("root", "");
             }
+            esbRequest.put(ESBProviderCallback.REQUEST, requestDoc);	    
 			QueuedExchangeContextImpl<java.util.Map, org.dom4j.Document> messageExchange = messageHandler.invoke(esbRequest, <%=!isOneWay%>);
 
 <% if (isOneWay) { %>


### PR DESCRIPTION
At this moment we can not process SOAP request with empty body due to "row1.payload can't be empty" exception which is thrown because of payload provided by tSOAPRequest component is null. Current fix puts to payload "empty" document with one "root" element to avoid such issue (and another similar issue which happends during message processing).