### PR TITLE
TESB-27101 Fix: enable use of context variable in cREST endpoint

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/components/cREST/cREST_main.javajet
@@ -77,7 +77,9 @@ imports="
                 endpointUrlStudio = "\"/" + endpointUrlStudio.substring(1);
             }
 
-           	endpointUrlStudio = defaultEndpointUrl + "+" + endpointUrlStudio;
+            if (!endpointUrlStudio.contains("context.")) {
+                endpointUrlStudio = defaultEndpointUrl + "+" + endpointUrlStudio;
+            }
         }
 
         boolean isTestContainer = ProcessUtils.isTestContainer(process);


### PR DESCRIPTION
Use of a context variable in endpoint parameter for a cREST component was working with 7.0.1 but is causing a compilation issue in Studio since 7.1.1. This fix allows now to use a context variable again.

I tested:
- Studio execution;
- Build as kar file and deployment in runtime;
- build as MS.