### PR TITLE
TESB-27207 Route containing config file fails when deployed

### DIFF
--- a/main/plugins/org.talend.camel.designer/resources/blueprint-template.xml
+++ b/main/plugins/org.talend.camel.designer/resources/blueprint-template.xml
@@ -108,7 +108,7 @@
 #foreach ($routelet in $routelets)
     <reference id="${routelet}" interface="org.apache.camel.RoutesBuilder" filter="(id=${routelet})" />
 #end
-    <camelContext id="${idName}" xmlns="http://camel.apache.org/schema/blueprint">
+    <camelContext id="${idName}" useBlueprintPropertyResolver="false" xmlns="http://camel.apache.org/schema/blueprint">
         <routeBuilder ref="route" />
 #foreach ($routelet in $routelets)
         <routeBuilder ref="${routelet}" />


### PR DESCRIPTION
Current issue is related to https://issues.apache.org/jira/browse/CAMEL-7456.
The problem is Camel by default uses blueprint properties resolver. Custom properties resolver is ignored in this case. Current behavior can be changed using useBlueprintPropertyResolver="false".
In this case BlueprintPropertyResolver will be used in case of custom properties resolver is not defined (in the same way it was working with Spring before migration to Blueprint)