### PR TITLE
TESB-28521, TPS-3906 tRouteFault causing 'javax.activation.DataHandler cannot be resolved'

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
@@ -74,6 +74,7 @@
                 name="camel-core">
             <library id="camel-core" />
             <library id="jakarta.xml.soap-api" />
+            <library id="javax.activation-1.2.0" />
             <group id="slf4j" />
         </libraryNeededGroup>
 


### PR DESCRIPTION
The cause of javax.activation.DataHandler exception is that we don't have javax.activation-1.2.0 library in classpath. For 7.3 version this issue is already fixed like in my PR