### PR TITLE
TESB-28314 'Sync' button cannot install user libraries by cConfig component

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/generator/SyncNexusButtonController.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/generator/SyncNexusButtonController.java
@@ -36,7 +36,6 @@ import org.talend.core.ui.properties.tab.IDynamicProperty;
 import org.talend.core.utils.TalendQuoteUtils;
 import org.talend.designer.maven.utils.PomUtil;
 import org.talend.librariesmanager.utils.DownloadModuleRunnable;
-import org.talend.librariesmanager.ui.LibManagerUiPlugin;
 
 public class SyncNexusButtonController extends ConfigOptionController {
 
@@ -86,7 +85,7 @@ public class SyncNexusButtonController extends ConfigOptionController {
             }
 
             tableViewerCreator.refresh();
-            LibManagerUiPlugin.getDefault().getLibrariesService().checkLibraries();
+
             return null;
         }
         return null;
@@ -196,6 +195,13 @@ public class SyncNexusButtonController extends ConfigOptionController {
                             } catch (Exception e) {
                                 e.printStackTrace();
                             }
+                        }
+
+                        ILibrariesService librariesService = (ILibrariesService) GlobalServiceRegister.getDefault()
+                                .getService(ILibrariesService.class);
+                           if (librariesService != null) {
+                                librariesService.syncLibraries();
+                                librariesService.checkLibraries();
                         }
 
                         monitor.subTask("Finished syncing " + jn + " from " + nexusServerBean.getServer());

--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/generator/SyncNexusButtonController.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/generator/SyncNexusButtonController.java
@@ -36,6 +36,7 @@ import org.talend.core.ui.properties.tab.IDynamicProperty;
 import org.talend.core.utils.TalendQuoteUtils;
 import org.talend.designer.maven.utils.PomUtil;
 import org.talend.librariesmanager.utils.DownloadModuleRunnable;
+import org.talend.librariesmanager.ui.LibManagerUiPlugin;
 
 public class SyncNexusButtonController extends ConfigOptionController {
 
@@ -85,7 +86,7 @@ public class SyncNexusButtonController extends ConfigOptionController {
             }
 
             tableViewerCreator.refresh();
-
+            LibManagerUiPlugin.getDefault().getLibrariesService().checkLibraries();
             return null;
         }
         return null;


### PR DESCRIPTION
Currently when we are installing Jars with 'Sync' button - they are successfully adding to <Studio installation>\configuration\.m2\repository\,
but Studio keeps displaying "Install..." button (like we still need to install those jars).
To make "Install..." button disappear, we just need to invoke syncLibraries() and checkLibraries()