### PR TITLE
TESB-29503 Bundle version does not use 'Custom Version'

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
@@ -622,8 +622,9 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                         new BundleModel(routeletModelGroupId, routeletBundleName, routeletModelVersion, routeletFile);
 
                 if (featuresModel.addBundle(routeletModel)) {
+                    String routeletBundleVersion = getArtifactVersion();
                     exportRouteBundle(referencedRouteletNode, routeletFile, routeletVersion, routeletBundleName,
-                            routeletBundleSymbolicName, bundleVersion, idSuffix, null,
+                            routeletBundleSymbolicName, routeletBundleVersion, idSuffix, null,
                             EmfModelUtils
                                     .findElementParameterByName(EParameterName.PROCESS_TYPE.getName() + ':'
                                             + EParameterName.PROCESS_TYPE_CONTEXT.getName(), node)

--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
@@ -315,7 +315,7 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                 final Set<String> routelets = new HashSet<>();
                 exportAllReferenceRoutelets(routeName, routeProcess, routelets);
 
-                exportRouteBundle(routeObject, routeFile, version, null, null, getArtifactVersion(), null, routelets, null);
+                exportRouteBundle(routeObject, routeFile, version, null, null, routeVersion, null, routelets, null);
             }
 
             try {

--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/actions/JavaCamelJobScriptsExportWSAction.java
@@ -315,7 +315,7 @@ public class JavaCamelJobScriptsExportWSAction implements IRunnableWithProgress 
                 final Set<String> routelets = new HashSet<>();
                 exportAllReferenceRoutelets(routeName, routeProcess, routelets);
 
-                exportRouteBundle(routeObject, routeFile, version, null, null, bundleVersion, null, routelets, null);
+                exportRouteBundle(routeObject, routeFile, version, null, null, getArtifactVersion(), null, routelets, null);
             }
 
             try {


### PR DESCRIPTION
The reason of this issue is that in MANIFEST.MF file 
(e.g. DemoRESTClientRoute6_0.1.kar\repository\org\example\local_project\route\DemoRESTClientRoute6\1.6.0\DemoRESTClientRoute6-1.6.0.jar\META-INF\MANIFEST.MF)
Bundle-Version field doesn't have value of custom version of the Job.
To fix this, we can replace bundleVersion with routeVersion variable. The routeVersion variable has value of Custom Version