### PR TITLE
TESB-29457 the different behavior after migration when the response code is 202

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.rs.consumer/components/tRESTClient/tRESTClient_main.javajet
+++ b/main/plugins/org.talend.designer.esb.components.rs.consumer/components/tRESTClient/tRESTClient_main.javajet
@@ -10,6 +10,7 @@
 		org.talend.designer.codegen.config.CodeGeneratorArgument
 		org.talend.designer.codegen.config.NodeConnectionsHelper
 		org.talend.designer.codegen.config.NodeParamsHelper
+		org.talend.core.model.process.IProcess
 	"
 %>
 <%
@@ -519,13 +520,25 @@ try {
 			}
 			<% } %>
 			
-			<% if (!MULTIPART_MIXED.equals(acceptType) && !"GET".equals(method)) { %>
-			// handle "oneway" for PUT, POST and PATCH with empty response payload
-			if (webClientResponseStatus_<%=cid%> == 202 && responseObj_<%=cid%> == null){
-				<%=connResponseName%>.string = "";
-				return;
-			}
-			<% } %>
+            <% if (!MULTIPART_MIXED.equals(acceptType) && !"GET".equals(method)) { %>
+            // handle "oneway" for PUT, POST and PATCH with empty response payload
+            if (webClientResponseStatus_<%=cid%> == 202 && responseObj_<%=cid%> == null){
+                    <%=connResponseName%>.string = "";
+                <%
+                boolean needResponse = false;
+                IProcess process = node.getProcess();
+			    List<? extends INode> graphicalNodes = process.getGraphicalNodes();
+                    for (INode graphicalNode : graphicalNodes) {
+                        if ("tRESTResponse".equals(graphicalNode.getComponent().getName()) ) {
+                           needResponse=true;
+                        }
+                    }
+                if(!needResponse) {
+                %>
+                    return;
+                <% } %>
+            }
+            <% } %>
 		<% } %>
 
 	} catch (javax.ws.rs.WebApplicationException ex_<%=cid%>) {

--- a/main/plugins/org.talend.designer.esb.components.rs.consumer/components/tRESTClient/tRESTClient_main.javajet
+++ b/main/plugins/org.talend.designer.esb.components.rs.consumer/components/tRESTClient/tRESTClient_main.javajet
@@ -527,7 +527,7 @@ try {
                 <%
                 boolean needResponse = false;
                 IProcess process = node.getProcess();
-			    List<? extends INode> graphicalNodes = process.getGraphicalNodes();
+                List<? extends INode> graphicalNodes = process.getGraphicalNodes();
                     for (INode graphicalNode : graphicalNodes) {
                         if ("tRESTResponse".equals(graphicalNode.getComponent().getName()) ) {
                            needResponse=true;


### PR DESCRIPTION
The reason of this issue is that tRestClient is used together with  tRestRequest and tRESTResponse in one Job.
In Job we have the following flow :
tRestRequest sends URL to tRestClient, tRestClient uses this URL to send POST request to other server. This server returns 202 response code with empty payload and currently if we have such case, request processing will be interrupted (with "return" statement in code). 
That's why response for tRESTResponse will not be generated and default code 404 will be return to initial request which 
was sent from tRestRequest. To avoid this issue we can add condition that if Job has tRESTResponse - we will not interrupt processing the request in case if tRestClient receives 202 code.
Then we'll get 200 response code from tRESTResponse insted of 404, which is expected.
![Untitled](https://user-images.githubusercontent.com/53863455/85611223-6c669800-b660-11ea-9f0c-ef68c7ccf6a4.png)
