### PR TITLE
Revert "fix(TESB-29645): NPE is thrown when route with 2 cRest components one…"

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/export/RouteJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/export/RouteJavaScriptOSGIForESBManager.java
@@ -463,7 +463,7 @@ public class RouteJavaScriptOSGIForESBManager extends AdaptedJobJavaScriptOSGIFo
                 }
                 useSAM |= nodeUseSAM;
 
-                useSL |= EmfModelUtils.computeCheckElementValue("ENABLE_SL", node) //$NON-NLS-1$
+                useSL = EmfModelUtils.computeCheckElementValue("ENABLE_SL", node) //$NON-NLS-1$
                         || EmfModelUtils.computeCheckElementValue("SERVICE_LOCATOR", node);
 
                 if (consumerNodes.contains(ElementParameterParser.getUNIQUENAME(node))) {


### PR DESCRIPTION
Reverts Talend/tesb-studio-se#802