### PR TITLE
TESB-29895 Set camel-saxon dependency compatible with TDM.

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
@@ -1032,7 +1032,7 @@
                  id="camel-saxon">
            </library>
            <library
-                 id="org.apache.servicemix.bundles.saxon">
+                 id="saxon-he">
            </library>
         </libraryNeededGroup>
         <libraryNeeded
@@ -1043,11 +1043,11 @@
         </libraryNeeded>
         <libraryNeeded
               context="plugin:org.talend.designer.camel.components.localprovider"
-              id="org.apache.servicemix.bundles.saxon"
-              name="${tesb-org.apache.servicemix.bundles.saxon}"
-              uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-org.apache.servicemix.bundles.saxon}"
-			  bundleID="" />
-        
+              id="saxon-he"
+              name="${tesb-Saxon-HE}"
+              uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-Saxon-HE}"
+              bundleID="" />
+
         <libraryNeededGroup
               description="camel-kafka-alldep"
               id="camel-kafka-alldep"

--- a/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
@@ -551,11 +551,11 @@
             <artifactId>camel-saxon</artifactId>
             <version>${camel.version}</version>
         </dependency>
-		<dependency>
-		    <groupId>org.apache.servicemix.bundles</groupId>
-		    <artifactId>org.apache.servicemix.bundles.saxon</artifactId>
-		    <version>9.8.0-8_1</version>
-		</dependency>
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.7.0-21</version>
+        </dependency>
 
         <!-- camel-kafka -->
         <dependency>


### PR DESCRIPTION
Fix for Studio and Microservice build setting the Saxon library used by camel-saxon to a version which does not conflict with TDM.