### PR TITLE
TESB-29895 Set camel-saxon dependency compatible with TDM.

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
@@ -1083,7 +1083,7 @@
                  id="camel-saxon">
            </library>
            <library
-                 id="Saxon-HE">
+                 id="saxon-he">
            </library>
         </libraryNeededGroup>
         <libraryNeeded
@@ -1093,12 +1093,11 @@
               uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-camel-saxon}">
         </libraryNeeded>
         <libraryNeeded
-              context="plugin:org.talend.designer.camel.components.localprovider"
-              id="org.apache.servicemix.bundles.saxon"
-              name="${tesb-org.apache.servicemix.bundles.saxon}"
-              uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-org.apache.servicemix.bundles.saxon}"
-			  bundleID="" />
-        
+              id="saxon-he"
+              name="${tesb-Saxon-HE}"
+              uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-Saxon-HE}"
+              bundleID="" />
+
         <libraryNeededGroup
               description="camel-kafka-alldep"
               id="camel-kafka-alldep"

--- a/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
@@ -48,7 +48,7 @@
         <azure-keyvault-core-version>1.0.0</azure-keyvault-core-version>
         <!-- camel-hawtdb -->
         <hawtdb-version>1.6</hawtdb-version>
-        <Saxon-HE-version>9.5.1-5</Saxon-HE-version>
+        <Saxon-HE-version>9.7.0-21</Saxon-HE-version>
         <!-- camel-kafka -->
         <kafka-clients-version>0.11.0.2</kafka-clients-version>
         <snappy-java-version>1.1.1.7</snappy-java-version>


### PR DESCRIPTION
Fix for Studio and Microservice build setting the Saxon library used by camel-saxon to a version which does not conflict with TDM.