### PR TITLE
TESB-30096 - Update Camel AMQP Netty version to 4.1.42.Final

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
@@ -23,7 +23,7 @@
         <!-- camel-amqp -->
         <qpid-jms-client.version>0.38.0</qpid-jms-client.version>
         <qpid-proton-j.version>0.30.0</qpid-proton-j.version>
-        <io-netty.version>4.1.31.Final</io-netty.version>
+        <io-netty.version>4.1.42.Final</io-netty.version>
         <geronimo-jms.version>1.1.1</geronimo-jms.version>
         <geronimo-j2ee-management.version>1.0.1</geronimo-j2ee-management.version>
         <!-- camel-mqtt -->


### PR DESCRIPTION
I tested Camel 2.24.2 AMQP with Netty 4.1.42.Final to make sure it works OK.