### PR TITLE
TESB-30549: Fixing for master: Investigate absence of require capabil…

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/JavaCamelJobScriptsExportWSWizardPage.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/wizards/JavaCamelJobScriptsExportWSWizardPage.java
@@ -842,6 +842,7 @@ public class JavaCamelJobScriptsExportWSWizardPage extends JobScriptsExportWizar
         JavaCamelJobScriptsExportWSAction action = null;
 
         IRunnableWithProgress buildJobHandlerAction = null;
+        IRunnableWithProgress buildJobHandlerPrepare = null;
         IRunnableWithProgress actionMS = null;
       
         Map<ExportChoice, Object> exportChoiceMap = getExportChoiceMap();
@@ -903,6 +904,26 @@ public class JavaCamelJobScriptsExportWSWizardPage extends JobScriptsExportWizar
 
                 exportChoiceMap.put(ExportChoice.esbExportType, "kar");
 
+                buildJobHandlerPrepare = new IRunnableWithProgress() {
+
+                    @Override
+                    public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+
+                        IBuildJobHandler buildJobHandler  = BuildJobFactory.createBuildJobHandler(getProcessItem(), getContextName(), version,
+                                            exportChoiceMap, "ROUTE");
+
+                        Map<String, Object> prepareParams = new HashMap<String, Object>();
+                        prepareParams.put(IBuildResourceParametes.OPTION_ITEMS, true);
+                        prepareParams.put(IBuildResourceParametes.OPTION_ITEMS_DEPENDENCIES, true);
+
+                        try {
+                              buildJobHandler.prepare(monitor, prepareParams);
+                        } catch (Exception e) {
+                            MessageBoxExceptionHandler.process(e.getCause() == null ? e : e.getCause(), getShell());
+                        }
+                    }
+                };
+
                 buildJobHandlerAction = new IRunnableWithProgress() {
 
                     @Override
@@ -942,8 +963,9 @@ public class JavaCamelJobScriptsExportWSWizardPage extends JobScriptsExportWizar
             }
 
             try {
+            	getContainer().run(false, true, buildJobHandlerPrepare);
             	getContainer().run(false, true, action);
-                getContainer().run(false, true, buildJobHandlerAction);
+            	getContainer().run(false, true, buildJobHandlerAction);
             } catch (Exception e) {
                 MessageBoxExceptionHandler.process(e.getCause(), getShell());
                 return false;


### PR DESCRIPTION
…ity in 7.4.1 and 7.3 builds

Build artifact first before scripts export.
The build steps fills in internal strucure which holds classes of the build,
which is used by Analyzer from bndlib to build corrrect require-capability statement.