### PR TITLE
TESB-30694: cawssqs fails in Runtime with error Could not find a suit…

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/plugin.xml
@@ -593,7 +593,8 @@
               context="plugin:org.talend.designer.camel.components.localprovider"
               id="aws-java-sdk-sqs"
               name="${tesb-aws-java-sdk-sqs}"
-              uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-aws-java-sdk-sqs}">
+              uripath="platform:/plugin/org.talend.designer.camel.components.localprovider/lib/${tesb-aws-java-sdk-sqs}"
+              bundleID="">
         </libraryNeeded>
         <libraryNeeded
               context="plugin:org.talend.designer.camel.components.localprovider"


### PR DESCRIPTION
…able setter for property: amazonSQSClient

Fix by setting jar bundleID to empty string. This influences library inclusion routine and causes the library to be excluded and thus fixing the bug.