### PR TITLE
TESB-30096 - Update Camel AMQP Netty version to 4.1.48.Final

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
@@ -23,7 +23,7 @@
         <!-- camel-amqp -->
         <qpid-jms-client.version>0.38.0</qpid-jms-client.version>
         <qpid-proton-j.version>0.30.0</qpid-proton-j.version>
-        <io-netty.version>4.1.42.Final</io-netty.version>
+        <io-netty.version>4.1.48.Final</io-netty.version>
         <geronimo-jms.version>1.1.1</geronimo-jms.version>
         <geronimo-j2ee-management.version>1.0.1</geronimo-j2ee-management.version>
         <!-- camel-mqtt -->


### PR DESCRIPTION
It turns out updating Netty to 4.1.42.Final isn't enough to fix the outstanding CVEs, so this is the second PR to update to 4.1.48.Final. I tested Camel AMQP 2.24.2 with Netty 4.1.48.Final and it seems to work.