### PR TITLE
TESB-32452: After applying the latest patch, trunjob component fails …

### DIFF
--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/view/handler/BuildBundleHandler.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/ui/view/handler/BuildBundleHandler.java
@@ -99,7 +99,7 @@ public class BuildBundleHandler extends BuildJobHandler {
         Property jobProperty = processItem.getProperty();
         boolean needLauncher = exportChoice.get(ExportChoice.needLauncher) != null;
         boolean needAssembly = exportChoice.get(ExportChoice.needAssembly) != null;
-        String jobName = JavaResourcesHelper.getJobJarName(jobProperty.getLabel(), jobProperty.getVersion())
+        String jobName = JavaResourcesHelper.getJobJarName(jobProperty)
                 + ((needLauncher && needAssembly) ? ".zip" : ".kar");
         IFolder targetFolder = talendProcessJavaProject.getTargetFolder();
         try {


### PR DESCRIPTION
…with "java.io.IOException: Cannot run program "java.exe": error=2, No such file or directory"