### PR TITLE
fix/APPINT-32037 upgrade jakarta.activation to 1.2.2(master branch)

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.ws.consumer/components/tESBConsumer/tESBConsumer_java.xml
+++ b/main/plugins/org.talend.designer.esb.components.ws.consumer/components/tESBConsumer/tESBConsumer_java.xml
@@ -378,8 +378,8 @@
                 UrlPath="platform:/plugin/org.talend.libraries.esb/lib/jakarta.activation-api-1.2.1.jar"
                 REQUIRED="true"/>
 
-            <IMPORT MODULE="jakarta.activation-1.2.1.jar" MVN="mvn:org.talend.libraries/jakarta.activation-1.2.1/6.0.0" NAME="jakarta.activation-1.2.1"
-                UrlPath="platform:/plugin/org.talend.libraries.esb/lib/jakarta.activation-1.2.1.jar"
+            <IMPORT MODULE="jakarta.activation-1.2.2.jar" MVN="mvn:org.talend.libraries/jakarta.activation-1.2.2/6.0.0" NAME="jakarta.activation-1.2.2"
+                UrlPath="platform:/plugin/org.talend.libraries.esb/lib/jakarta.activation-1.2.2.jar"
                 REQUIRED="true"/>
                 
 		</IMPORTS>


### PR DESCRIPTION
fix problem:
Component tESBConsumer requires jakarta.activation-1.2.1.jar which can not be downloaded automatically

I see it is upgraded to 1.2.2 in https://github.com/Talend/tcommon-studio-se/commit/cf0477ac20c365126c37a3aa62af01d96984fffd .
so I upgrade it to 1.2.2

 

so need to upgrade version to jakarta.activation-1.2.2