### PR TITLE
fix for APPINT-33209

### DIFF
--- a/main/plugins/org.talend.designer.esb.components.ws.consumer/components/tESBConsumer/tESBConsumer_main.javajet
+++ b/main/plugins/org.talend.designer.esb.components.ws.consumer/components/tESBConsumer/tESBConsumer_main.javajet
@@ -132,7 +132,7 @@ if (inputConn != null) {
 
 	 final List<java.util.Map<String, String>> customHttpHeaders_<%=cid%> = new java.util.ArrayList<java.util.Map<String, String>>();
 	 final HttpHeadersFeature httpHeadersFeature_<%=cid%> = new HttpHeadersFeature(customHttpHeaders_<%=cid%>);
-	
+    Boolean isResponseCode202 = null;
     try {
         routines.system.Document requestTalendDoc_<%=cid%> = <%=inputConn.getName()%>.payload;
         try {
@@ -222,7 +222,6 @@ if (inputConn != null) {
                }
             }
             <%}%>
-            
             if (null == registry) {
                 GenericConsumer genericConsumer_<%=cid%> = new GenericConsumer();
                 genericConsumer_<%=cid%>.setServiceQName(serviceName_<%=cid%>);
@@ -323,7 +322,11 @@ if (inputConn != null) {
                     globalMap.put("<%=cid%>_CORRELATION_ID", genericConsumer_<%=cid%>.getCorrelationID());
                 <% } %>
                 globalMap.put("<%=cid%>_HTTP_HEADERS", httpHeadersFeature_<%=cid%>.getResponseHeaders());
-                globalMap.put("<%=cid%>_HTTP_RESPONSE_CODE", httpHeadersFeature_<%=cid%>.getResponseCode());
+                if(202 == genericConsumer_<%=cid%>.getHttpResponseCode()) {
+                   isResponseCode202 = true;
+                }else{
+                    globalMap.put("<%=cid%>_HTTP_RESPONSE_CODE", httpHeadersFeature_<%=cid%>.getResponseCode());
+                }
             } else {
                 ESBConsumer consumer_<%=cid%> = registry.createConsumer(
                     new ESBEndpointInfo() {
@@ -502,9 +505,11 @@ if (inputConn != null) {
         <% } %>
     }
     
-    if(httpHeadersFeature_<%=cid%>!=null){
-    	 globalMap.put("<%=cid%>_HTTP_HEADERS", httpHeadersFeature_<%=cid%>.getResponseHeaders());
-       globalMap.put("<%=cid%>_HTTP_RESPONSE_CODE",  httpHeadersFeature_<%=cid%>.getResponseCode());
+    if (Boolean.TRUE.equals(isResponseCode202)) {
+        globalMap.put("tESBConsumer_1_HTTP_RESPONSE_CODE", 202);
+    } else if(httpHeadersFeature_<%=cid%> != null) {
+        globalMap.put("<%=cid%>_HTTP_HEADERS", httpHeadersFeature_<%=cid%>.getResponseHeaders());
+        globalMap.put("<%=cid%>_HTTP_RESPONSE_CODE", httpHeadersFeature_<%=cid%>.getResponseCode());
     }
 
 <% } %>


### PR DESCRIPTION
APPINT-33209 [7.3.1] HTTP response code cannot be retrieved using global variable tESBConsumer_1_HTTP_RESPONSE_CODE with one way webservice

Solution: return response code 202