### PR TITLE
APPINT-33290 upgrade camel-wmq to 3.11.0

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
@@ -15,7 +15,7 @@
 		<!-- <camel.version>2.25.2</camel.version> -->
 		<camel.version>3.9.0</camel.version>
 		<camel.mqtt.version>${camel.version}.tesb1</camel.mqtt.version>
-		<camel.wmq.version>${camel.version}</camel.wmq.version>
+		<camel.wmq.version>3.11.0</camel.wmq.version>
 		<!-- camel-groovy -->
 		<groovy.version>2.4.8</groovy.version>
 		<!-- camel-xstream -->


### PR DESCRIPTION
APPINT-33290 [741 camel3] Missing camel-wmq-alldep-3.9.0.jar for cMQConnectionFactory with WebSphere MQ server

fix solution:
upgrade camel-wmq-alldep to 3.11.0