### PR TITLE
TUP-34420 In 8.0 patch, there are some libraries plugin's version can't

### DIFF
--- a/main/plugins/org.talend.libraries.esb/pom.xml
+++ b/main/plugins/org.talend.libraries.esb/pom.xml
@@ -9,7 +9,10 @@
   </parent>
   <artifactId>org.talend.libraries.esb</artifactId>
   <packaging>eclipse-plugin</packaging>
-
+  
+  	<properties>
+		<tycho.buildtimestamp.format>20220112_1100</tycho.buildtimestamp.format>
+	</properties>
    <build>
     <plugins>
        <plugin>


### PR DESCRIPTION
TUP-34420 In 8.0 patch, there are some libraries plugin's version can't update that cause Studio can't apply it.
https://jira.talendforge.org/browse/TUP-34420