### PR TITLE
APPINT-32549 remove /services in endpoint for cSOAP|cREST|tRESTRequest

### DIFF
--- a/main/plugins/org.talend.camel.designer.codegen/resources/header_route.javajet
+++ b/main/plugins/org.talend.camel.designer.codegen/resources/header_route.javajet
@@ -1438,7 +1438,7 @@ static class CxfPayloadProvider implements javax.ws.rs.ext.MessageBodyWriter<org
 %>
             @org.springframework.context.annotation.Bean
             public org.springframework.boot.web.servlet.ServletRegistrationBean servletRegistrationBean(org.springframework.context.ApplicationContext context) {
-                return new org.springframework.boot.web.servlet.ServletRegistrationBean(new org.apache.cxf.transport.servlet.CXFServlet(), "/services/*");
+                return new org.springframework.boot.web.servlet.ServletRegistrationBean(new org.apache.cxf.transport.servlet.CXFServlet(), "/*");
             }
             @org.springframework.context.annotation.Bean(name = "cxf")
             public org.apache.cxf.bus.spring.SpringBus springBus() {

--- a/main/plugins/org.talend.camel.designer/plugin.xml
+++ b/main/plugins/org.talend.camel.designer/plugin.xml
@@ -481,6 +481,15 @@
                 id="org.talend.camel.designer.migration.CSetPropertyExchangePropertyMigrationTask"
                 name="CSetPropertyExchangePropertyMigrationTask"
                 version="7.4.1">
+            <projecttask
+                beforeLogon="false"
+                breaks="7.3.1"
+                class="org.talend.camel.designer.migration.RemoveSlashServicesInEndpointMigrationTask"
+                description="Remove '/services' in endpoint for tRESTRequest|cREST|cSOAP component"
+                id="org.talend.camel.designer.migration.RemoveSlashServicesInEndpointMigrationTask"
+                name="RemoveSlashServicesInEndpointMigrationTask"
+                version="8.0.1">
+          </projecttask>
           </projecttask>
     </extension>
 

--- a/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/migration/RemoveSlashServicesInEndpointMigrationTask.java
+++ b/main/plugins/org.talend.camel.designer/src/main/java/org/talend/camel/designer/migration/RemoveSlashServicesInEndpointMigrationTask.java
@@ -1,0 +1,111 @@
+// ============================================================================
+package org.talend.camel.designer.migration;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.talend.commons.exception.ExceptionHandler;
+import org.talend.commons.exception.PersistenceException;
+import org.talend.core.model.migration.AbstractItemMigrationTask;
+import org.talend.core.model.properties.Item;
+import org.talend.core.model.properties.ProcessItem;
+import org.talend.core.model.repository.ERepositoryObjectType;
+import org.talend.core.repository.model.ProxyRepositoryFactory;
+import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
+import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
+import org.talend.migration.MigrationReportRecorder;
+
+public class RemoveSlashServicesInEndpointMigrationTask extends AbstractItemMigrationTask {
+
+    final private String prefix = "\"/services";
+    final private Map<String, String> nodeNameEndpointNameMap = new HashMap<String, String>() {
+        private static final long serialVersionUID = 1L;
+        {
+            put("cSOAP", "ADDRESS");
+            put("cREST", "URL");
+            put("tRESTRequest", "REST_ENDPOINT");
+        }
+    };
+
+    @Override
+    public List<ERepositoryObjectType> getTypes() {
+        List<ERepositoryObjectType> toReturn = new ArrayList<ERepositoryObjectType>();
+        toReturn.add(ERepositoryObjectType.PROCESS);
+        toReturn.add(ERepositoryObjectType.JOBLET);
+        toReturn.add(ERepositoryObjectType.TEST_CONTAINER);
+        toReturn.add(ERepositoryObjectType.PROCESS_ROUTE);
+        toReturn.add(ERepositoryObjectType.PROCESS_ROUTE_DESIGN);
+        toReturn.add(ERepositoryObjectType.PROCESS_ROUTE_MICROSERVICE);
+        toReturn.add(ERepositoryObjectType.PROCESS_ROUTELET);
+        return toReturn;
+    }
+
+    @Override
+    public ExecutionResult execute(Item item) {
+        ProcessType processType = null;
+        if (item instanceof ProcessItem) {
+            processType = ((ProcessItem) item).getProcess();
+        }
+
+        boolean modified = false;
+        for (Object o : processType.getNode()) {
+            if (o instanceof NodeType) {
+                NodeType currentNode = (NodeType) o;
+                String componentName = currentNode.getComponentName();
+                if (nodeNameEndpointNameMap.keySet().contains(componentName)) {
+                    modified |= removeSlashServicesInEndpoint(currentNode, item);
+                }
+            }
+        }
+
+        if (modified) {
+            try {
+                ProxyRepositoryFactory.getInstance().save(item);
+            } catch (PersistenceException e) {
+                ExceptionHandler.process(e);
+                return ExecutionResult.FAILURE;
+            }
+            return ExecutionResult.SUCCESS_NO_ALERT;
+        } else {
+            return ExecutionResult.NOTHING_TO_DO;
+        }
+    }
+
+    @Override
+    public Date getOrder() {
+        return new GregorianCalendar(2022, 03, 03, 00, 00, 00).getTime();
+    }
+
+    private boolean needKeepEndpoint(String endpoint) {
+        return endpoint.startsWith("\"http://") || endpoint.startsWith("\"https://") || endpoint.startsWith("context.");
+    }
+
+    private boolean removeSlashServicesInEndpoint(NodeType currentNode, Item item) {
+        boolean modified = false;
+        String nodeName = currentNode.getComponentName();
+        String endpointEleName = nodeNameEndpointNameMap.get(nodeName);
+
+        for (Object e : currentNode.getElementParameter()) {
+            ElementParameterType p = (ElementParameterType) e;
+            if (p.getName().equals(endpointEleName)) {
+                String endpoint = p.getValue().replace(" ", "");
+                // will keep absolute URL as it is. Only remove relative URL's first
+                // "/services".
+                if (!needKeepEndpoint(endpoint) && endpoint.startsWith(prefix)) {
+                    String newEndpoint = "\"" + endpoint.substring(prefix.length());
+                    p.setValue(newEndpoint);
+                    modified = true;
+                    generateReportRecord(
+                            new MigrationReportRecorder(this, MigrationReportRecorder.MigrationOperationType.MODIFY,
+                                    item, currentNode, "Endpoint", endpoint, newEndpoint));
+                }
+            }
+        }
+        return modified;
+    }
+}


### PR DESCRIPTION
for APPINT-32549: CXF Component (REST and SOAP) endpoint uses "/services" by default when built as MS

1. Replace /services as /* for default registed servlet.
2. update ESB demo, update endpoint and remove /services in endpoints of task DemoREST, DemoRESTConsumer, DemoRESTRoute, DemoRESTClientRoute, SOAPtoREST.
3. Add migration task: RemoveSlashServicesInEndpointMigrationTask