### PR TITLE
Appint security 8.0.1 r2023 12 (#2142)

### DIFF
--- a/main/plugins/org.talend.designer.camel.components.localprovider/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: CamelLocalprovider 8.0.1-R2023-11
+Bundle-Name: CamelLocalprovider 8.0.1-R2023-12
 Bundle-SymbolicName: org.talend.designer.camel.components.localprovider;singleton:=true
 Bundle-Version: 8.8.8.qualifier
 Bundle-Activator: org.talend.designer.camel.components.localprovider.CamelComponentPlugin

--- a/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.camel.components.localprovider/pom.xml
@@ -66,7 +66,7 @@
 		<mvn-commons-io>mvn:commons-io/commons-io/2.10.0</mvn-commons-io>
 		<mvn-commons-lang>mvn:commons-lang/commons-lang/2.6</mvn-commons-lang>
 		<mvn-commons-pool>mvn:commons-pool/commons-pool/1.6</mvn-commons-pool>
-		<jetty-all.version>9.4.51.v20230217</jetty-all.version>
+		<jetty-all.version>9.4.53.v20231009</jetty-all.version>
 		<javax.servlet-api.version>3.1.0</javax.servlet-api.version>
 		<reactive.streams.version>1.0.4</reactive.streams.version>
 		<hamcrest.version>1.3</hamcrest.version>

--- a/main/plugins/org.talend.designer.esb.components.rs.consumer/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.designer.esb.components.rs.consumer/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %pluginName 8.0.1-2023-11
+Bundle-Name: %pluginName 8.0.1-2023-12
 Bundle-SymbolicName: org.talend.designer.esb.components.rs.consumer;singleton:=true
 Bundle-Version: 8.8.8.qualifier
 Bundle-Vendor: %providerName

--- a/main/plugins/org.talend.designer.esb.components.rs.consumer/plugin.xml
+++ b/main/plugins/org.talend.designer.esb.components.rs.consumer/plugin.xml
@@ -397,10 +397,10 @@
 		    uripath="platform:/plugin/org.talend.libraries.esb/lib/${tesb-wss4j-ws-security-common}"
 		    bundleID="" />
 		<libraryNeeded context="plugin:org.talend.libraries.esb"
-		    name="${tesb-xmlsec}"
+		    name="xmlsec-${xmlsec.version}.jar"
 		    id="xmlsec"
 		    mvn_uri="mvn:org.apache.santuario/xmlsec/${xmlsec.version}"
-		    uripath="platform:/plugin/org.talend.libraries.esb/lib/${tesb-xmlsec}"
+		    uripath="platform:/plugin/org.talend.libraries.esb/lib/xmlsec-${xmlsec.version}.jar"
 		    bundleID="" />
 		<libraryNeeded context="plugin:org.talend.libraries.esb"
 		    name="commons-codec-1.15.jar"

--- a/main/plugins/org.talend.designer.esb.components.ws.consumer/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.designer.esb.components.ws.consumer/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %pluginName 8.0.1-2023-11
+Bundle-Name: %pluginName 8.0.1-2023-12
 Bundle-SymbolicName: org.talend.designer.esb.components.ws.consumer;singleton:=true
 Bundle-Version: 8.8.8.qualifier
 Bundle-Vendor: %providerName

--- a/main/plugins/org.talend.designer.esb.components.ws.consumer/plugin.xml
+++ b/main/plugins/org.talend.designer.esb.components.ws.consumer/plugin.xml
@@ -428,10 +428,10 @@
             uripath="platform:/plugin/org.talend.libraries.esb/lib/${tesb-wss4j-ws-security-common}"
             bundleID="" />
         <libraryNeeded context="plugin:org.talend.libraries.esb"
-            name="${tesb-xmlsec}"
+            name="xmlsec-${xmlsec.version}.jar"
             id="xmlsec"
             mvn_uri="mvn:org.apache.santuario/xmlsec/${xmlsec.version}"
-            uripath="platform:/plugin/org.talend.libraries.esb/lib/${tesb-xmlsec}"
+            uripath="platform:/plugin/org.talend.libraries.esb/lib/xmlsec-${xmlsec.version}.jar"
             bundleID="" />
         <libraryNeeded context="plugin:org.talend.libraries.esb"
             name="commons-codec-1.15.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jackson.databind.version>2.14.3</jackson.databind.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
     <activemq.version>5.17.6</activemq.version>
-    <xmlsec.version>2.2.3</xmlsec.version>
+    <xmlsec.version>2.2.6</xmlsec.version>
     <wss4j.version>2.4.1</wss4j.version>
     <opensaml.version>3.4.6</opensaml.version>
     <joda-time.version>2.10.10</joda-time.version>


### PR DESCRIPTION
* APPINT-35983 CVE-2023-36478 org.eclipse.jetty.http2:http2-hpack 9.4.51.v20230217|org.eclipse.jetty:jetty-http:9.4.51.v20230217 (#2133)

* APPINT-36035 xmlsec:2.2.3 | CVE-2023-44483 (#2135)

* APPINT-36035 xmlsec:2.2.3 | CVE-2023-44483

* update jar names in plugin.xml